### PR TITLE
[FEAT] Yahoo API 활용한 해외 지수 조회

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,7 +127,6 @@ jobs:
             -e ALPACA_OAUTH_CLIENT_SECRET="${{ secrets.ALPACA_OAUTH_CLIENT_SECRET }}" \
             -e OAUTH_STATE_SECRET="${{ secrets.OAUTH_STATE_SECRET }}" \
             -e STOCK_SYNC_ON="${{ secrets.STOCK_SYNC_ON }}" \
-            -e POLYGON_API_KEY="${{ secrets.POLYGON_API_KEY }}" \
             -e INFO_APP_VERSION="${{ github.sha }}" \
             ${{ secrets.DOCKER_REPO }}:${{ github.sha }}
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -127,6 +127,7 @@ jobs:
             -e ALPACA_OAUTH_CLIENT_SECRET="${{ secrets.ALPACA_OAUTH_CLIENT_SECRET }}" \
             -e OAUTH_STATE_SECRET="${{ secrets.OAUTH_STATE_SECRET }}" \
             -e STOCK_SYNC_ON="${{ secrets.STOCK_SYNC_ON }}" \
+            -e POLYGON_API_KEY="${{ secrets.POLYGON_API_KEY }}" \
             -e INFO_APP_VERSION="${{ github.sha }}" \
             ${{ secrets.DOCKER_REPO }}:${{ github.sha }}
 

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/QbitApiApplication.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/QbitApiApplication.java
@@ -6,12 +6,17 @@ import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = "com.curihous.qbit")
 @EnableJpaRepositories(basePackages = {"com.curihous.qbit.domain"})
 @EntityScan(basePackages = {"com.curihous.qbit.domain"})
 @EnableJpaAuditing
-@EnableFeignClients(basePackages = "com.curihous.qbit.infra.alpaca.client")
+@EnableScheduling
+@EnableFeignClients(basePackages = {
+        "com.curihous.qbit.infra.alpaca.client",
+        "com.curihous.qbit.infra.yahoo.client"
+})
 public class QbitApiApplication {
 
     public static void main(String[] args) {

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/auth/controller/AuthController.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/auth/controller/AuthController.java
@@ -1,7 +1,7 @@
 package com.curihous.qbit.api.domain.auth.controller;
 
-import com.curihous.qbit.api.domain.auth.dto.KakaoLoginRequest;
-import com.curihous.qbit.api.domain.auth.dto.KakaoLoginResponse;
+import com.curihous.qbit.api.domain.auth.dto.request.KakaoLoginRequestDto;
+import com.curihous.qbit.api.domain.auth.dto.response.KakaoLoginResponseDto;
 import com.curihous.qbit.infra.kakao.service.KakaoLoginService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -31,8 +31,8 @@ public class AuthController {
             @ApiResponse(responseCode = "400", description = "잘못된 요청"),
             @ApiResponse(responseCode = "401", description = "유효하지 않은 카카오 액세스 토큰")
     })
-    public ResponseEntity<KakaoLoginResponse> kakaoLogin(
-            @Valid @RequestBody KakaoLoginRequest request,
+    public ResponseEntity<KakaoLoginResponseDto> kakaoLogin(
+            @Valid @RequestBody KakaoLoginRequestDto request,
             HttpServletResponse response) {
         
         Map<String, Object> result = kakaoLoginService.loginWithKakao(
@@ -40,7 +40,7 @@ public class AuthController {
                 response
         );
         
-        KakaoLoginResponse loginResponse = new KakaoLoginResponse(
+        KakaoLoginResponseDto loginResponse = new KakaoLoginResponseDto(
                 (String) result.get("accessToken"),
                 (Integer) result.get("expiresIn"),
                 (Boolean) result.get("isNewUser"),

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/auth/dto/request/KakaoLoginRequestDto.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/auth/dto/request/KakaoLoginRequestDto.java
@@ -1,12 +1,14 @@
-package com.curihous.qbit.api.domain.auth.dto;
+package com.curihous.qbit.api.domain.auth.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
 
 /**
  * 카카오 네이티브 앱 로그인 요청 DTO
- * Flutter SDK에서 받은 카카오 액세스 토큰을 전달받음
+ * 
+ * 사용 API:
+ * - POST /auth/kakao/login
  */
-public record KakaoLoginRequest(
+public record KakaoLoginRequestDto(
     @NotBlank
     String kakaoAccessToken
 ) {

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/auth/dto/response/KakaoLoginResponseDto.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/auth/dto/response/KakaoLoginResponseDto.java
@@ -1,11 +1,14 @@
-package com.curihous.qbit.api.domain.auth.dto;
+package com.curihous.qbit.api.domain.auth.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * 카카오 네이티브 앱 로그인 응답 DTO
+ * 
+ * 사용 API:
+ * - POST /auth/kakao/login
  */
-public record KakaoLoginResponse(
+public record KakaoLoginResponseDto(
     @Schema(description = "JWT 액세스 토큰")
     String accessToken,
     

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/stock/controller/MarketIndexController.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/stock/controller/MarketIndexController.java
@@ -1,0 +1,85 @@
+package com.curihous.qbit.api.domain.stock.controller;
+
+import com.curihous.qbit.api.domain.stock.dto.response.MarketIndexHistoryDto;
+import com.curihous.qbit.api.domain.stock.dto.response.MarketIndexResponseDto;
+import com.curihous.qbit.api.domain.stock.dto.response.MarketIndexSummaryDto;
+import com.curihous.qbit.domain.stock.entity.MarketIndex;
+import com.curihous.qbit.domain.stock.port.MarketIndexPort;
+import com.curihous.qbit.domain.stock.service.MarketIndexService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RestController
+@RequestMapping("/indices")
+@RequiredArgsConstructor
+@Tag(name = "Stock - Index", description = "해외 주요 지수 API입니다.")
+public class MarketIndexController {
+
+    private final MarketIndexService marketIndexService;
+    private final MarketIndexPort marketIndexPort;
+
+    @GetMapping
+    @Operation(summary = "주요 지수 목록 조회", description = "해외 주요 지수 목록을 조회합니다. (홈 화면용)")
+    public ResponseEntity<List<MarketIndexSummaryDto>> getMajorIndices() {
+        List<MarketIndex> indices = marketIndexService.getMajorIndices();
+        List<MarketIndexSummaryDto> response = indices.stream()
+                .map(MarketIndexSummaryDto::fromEntity)
+                .collect(Collectors.toList());
+        return ResponseEntity.ok(response);
+    }
+
+
+    @GetMapping("/{symbol}")
+    @Operation(summary = "특정 지수 상세 조회", description = "심볼로 특정 지수의 상세 정보를 조회합니다.")
+    public ResponseEntity<MarketIndexResponseDto> getIndexBySymbol(
+            @PathVariable String symbol) {
+        
+        // 허용된 지수 심볼만 조회 가능
+        marketIndexService.validateIndexSymbol(symbol);
+        
+        MarketIndex index = marketIndexPort.getOrFetchIndex(symbol);
+        MarketIndexResponseDto response = MarketIndexResponseDto.fromEntity(index);
+        
+        log.info("지수 조회: {} - {}", symbol, index.getName());
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{symbol}/history")
+    @Operation(summary = "지수 과거 데이터 조회", description = "특정 지수의 과거 데이터를 조회합니다. (차트용)")
+    public ResponseEntity<List<MarketIndexHistoryDto>> getIndexHistory(
+            @Parameter(description = "지수 심볼", example = "^GSPC")
+            @PathVariable String symbol,
+            @Parameter(description = "시작일 (yyyy-MM-dd)", example = "2024-01-01")
+            @RequestParam String from,
+            @Parameter(description = "종료일 (yyyy-MM-dd)", example = "2024-12-31")
+            @RequestParam String to) {
+
+        // 허용된 지수 심볼만 조회 가능
+        marketIndexService.validateIndexSymbol(symbol);
+
+        MarketIndexPort.MarketIndexHistoryData data = marketIndexPort.getIndexHistory(symbol, from, to);
+        
+        List<MarketIndexHistoryDto> response = data.dataPoints().stream()
+            .map(point -> new MarketIndexHistoryDto(
+                point.timestamp(),
+                point.openPrice(),
+                point.closePrice(),
+                point.highPrice(),
+                point.lowPrice(),
+                point.volume()
+            ))
+            .collect(Collectors.toList());
+
+        log.info("지수 과거 데이터 조회: {} ({} ~ {}), {}건", symbol, from, to, response.size());
+        return ResponseEntity.ok(response);
+    }
+}

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/stock/controller/StockController.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/stock/controller/StockController.java
@@ -1,11 +1,11 @@
 package com.curihous.qbit.api.domain.stock.controller;
 
-import com.curihous.qbit.api.domain.stock.dto.StockDetailResponseDto;
-import com.curihous.qbit.api.domain.stock.dto.StockSearchResponseDto;
+import com.curihous.qbit.api.domain.stock.dto.response.StockDetailResponseDto;
+import com.curihous.qbit.api.domain.stock.dto.response.StockSearchResponseDto;
 import com.curihous.qbit.domain.stock.entity.Stock;
+import com.curihous.qbit.domain.stock.port.StockPort;
 import com.curihous.qbit.domain.stock.service.StockService;
 import com.curihous.qbit.domain.user.entity.User;
-import com.curihous.qbit.infra.alpaca.service.AlpacaStockService;
 import com.curihous.qbit.infra.security.facade.UserSecurityFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -19,14 +19,14 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 @Slf4j
-@Tag(name = "Stock", description = "주식 종목 관련 API입니다")
+@Tag(name = "Stock", description = "주식 종목 관련 API입니다.")
 @RestController
 @RequestMapping("/stocks")
 @RequiredArgsConstructor
 public class StockController {
 
     private final StockService stockService;
-    private final AlpacaStockService alpacaStockService;
+    private final StockPort stockPort; 
     private final UserSecurityFacade userSecurityFacade;
 
     @Operation(
@@ -46,7 +46,7 @@ public class StockController {
             stocks.isEmpty() && keyword.matches("^[A-Z]{1,5}$")) {
             try {
                 User user = userSecurityFacade.getCurrentUser();
-                Stock stock = alpacaStockService.getOrFetchStock(user, keyword);
+                Stock stock = stockPort.getOrFetchStock(user, keyword);
                 
                 // 미국 주식만 허용 (코인 등 제외)
                 if ("us_equity".equalsIgnoreCase(stock.getAssetClass())) {
@@ -76,8 +76,8 @@ public class StockController {
             @PathVariable String symbol
     ) {
         User user = userSecurityFacade.getCurrentUser();
-        // Cache-Aside: DB 우선 → 없으면 Alpaca API 조회 → 저장
-        Stock stock = alpacaStockService.getOrFetchStock(user, symbol);
+        // Cache-Aside: DB 우선 → 없으면 Alpaca API API 조회 → 저장
+        Stock stock = stockPort.getOrFetchStock(user, symbol);
         return ResponseEntity.ok(StockDetailResponseDto.fromEntity(stock));
     }
 }

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/stock/dto/response/MarketIndexHistoryDto.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/stock/dto/response/MarketIndexHistoryDto.java
@@ -1,0 +1,34 @@
+package com.curihous.qbit.api.domain.stock.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+
+/**
+ * 지수 과거 데이터 DTO (차트용)
+ * 
+ * 사용 API:
+ * - GET /indices/{symbol}/history
+ */
+@Schema(description = "지수 과거 데이터 (차트용)")
+public record MarketIndexHistoryDto(
+        @Schema(description = "타임스탬프 (밀리초)", example = "1704067200000")
+        Long timestamp,
+
+        @Schema(description = "시가", example = "4700.50")
+        BigDecimal open,
+
+        @Schema(description = "종가", example = "4750.20")
+        BigDecimal close,
+
+        @Schema(description = "고가", example = "4760.80")
+        BigDecimal high,
+
+        @Schema(description = "저가", example = "4690.30")
+        BigDecimal low,
+
+        @Schema(description = "거래량", example = "50000000")
+        Long volume
+) {
+}
+

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/stock/dto/response/MarketIndexResponseDto.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/stock/dto/response/MarketIndexResponseDto.java
@@ -1,0 +1,78 @@
+package com.curihous.qbit.api.domain.stock.dto.response;
+
+import com.curihous.qbit.domain.stock.entity.MarketIndex;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+/**
+ * 해외 주요 지수 상세 DTO
+ * 
+ * 사용 API:
+ * - GET /indices/{symbol}
+ */
+@Schema(description = "해외 주요 지수 상세 정보")
+public record MarketIndexResponseDto(
+        @Schema(description = "지수 심볼", example = "^GSPC")
+        String symbol,
+
+        @Schema(description = "지수명", example = "S&P 500")
+        String name,
+
+        @Schema(description = "지수 설명", example = "미국 S&P 500 주식 지수")
+        String description,
+
+        @Schema(description = "국가", example = "US")
+        String country,
+
+        @Schema(description = "통화", example = "USD")
+        String currency,
+
+        @Schema(description = "현재 가격", example = "5911.69")
+        BigDecimal currentPrice,
+
+        @Schema(description = "전일 종가", example = "5900.00")
+        BigDecimal previousClose,
+
+        @Schema(description = "변동 금액", example = "11.69")
+        BigDecimal changeAmount,
+
+        @Schema(description = "변동률(%)", example = "0.20")
+        BigDecimal changePercentage,
+
+        @Schema(description = "거래량", example = "50000000")
+        Long volume,
+
+        @Schema(description = "시가총액", example = "500000000000")
+        Long marketCap,
+
+        @Schema(description = "마지막 업데이트 시간", example = "2025-01-11T19:30:00")
+        LocalDateTime lastUpdated,
+
+        @Schema(description = "상승/하락 여부", example = "true")
+        Boolean isPositive,
+
+        @Schema(description = "활성화 여부", example = "true")
+        Boolean isActive
+) {
+    public static MarketIndexResponseDto fromEntity(MarketIndex marketIndex) {
+        return new MarketIndexResponseDto(
+                marketIndex.getSymbol(),
+                marketIndex.getName(),
+                marketIndex.getDescription(),
+                marketIndex.getCountry(),
+                marketIndex.getCurrency(),
+                marketIndex.getCurrentPrice(),
+                marketIndex.getPreviousClose(),
+                marketIndex.getChangeAmount(),
+                marketIndex.getChangePercentage(),
+                marketIndex.getVolume(),
+                marketIndex.getMarketCap(),
+                marketIndex.getLastUpdated(),
+                marketIndex.isPositive(),
+                marketIndex.getIsActive()
+        );
+    }
+}
+

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/stock/dto/response/MarketIndexSummaryDto.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/stock/dto/response/MarketIndexSummaryDto.java
@@ -1,0 +1,45 @@
+package com.curihous.qbit.api.domain.stock.dto.response;
+
+import com.curihous.qbit.domain.stock.entity.MarketIndex;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import java.math.BigDecimal;
+
+/**
+ * 해외 주요 지수 요약 DTO
+ * 
+ * 사용 API:
+ * - GET /indices
+ */
+@Schema(description = "해외 주요 지수 요약 정보 (홈 화면용)")
+public record MarketIndexSummaryDto(
+        @Schema(description = "지수 심볼", example = "^GSPC")
+        String symbol,
+
+        @Schema(description = "지수명", example = "S&P 500")
+        String name,
+
+        @Schema(description = "현재 가격", example = "5911.69")
+        BigDecimal currentPrice,
+
+        @Schema(description = "변동 금액", example = "11.69")
+        BigDecimal changeAmount,
+
+        @Schema(description = "변동률(%)", example = "0.20")
+        BigDecimal changePercentage,
+
+        @Schema(description = "상승/하락 여부", example = "true")
+        Boolean isPositive
+) {
+    public static MarketIndexSummaryDto fromEntity(MarketIndex marketIndex) {
+        return new MarketIndexSummaryDto(
+                marketIndex.getSymbol(),
+                marketIndex.getName(),
+                marketIndex.getCurrentPrice(),
+                marketIndex.getChangeAmount(),
+                marketIndex.getChangePercentage(),
+                marketIndex.isPositive()
+        );
+    }
+}
+

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/stock/dto/response/StockDetailResponseDto.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/stock/dto/response/StockDetailResponseDto.java
@@ -1,7 +1,6 @@
-package com.curihous.qbit.api.domain.stock.dto;
+package com.curihous.qbit.api.domain.stock.dto.response;
 
 import com.curihous.qbit.domain.stock.entity.Stock;
-import com.curihous.qbit.infra.alpaca.dto.response.AlpacaAssetResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
@@ -47,7 +46,6 @@ public record StockDetailResponseDto(
     String logoUrl
 ) {
     
-    // Stock 엔티티를 StockDetailResponseDto로 변환 (DB 조회용)
     public static StockDetailResponseDto fromEntity(Stock stock) {
         return new StockDetailResponseDto(
                 stock.getSymbol(),
@@ -63,21 +61,5 @@ public record StockDetailResponseDto(
                 stock.getLogoUrl()
         );
     }
-    
-    // AlpacaAssetResponse를 StockDetailResponseDto로 변환 (API 조회용)
-    public static StockDetailResponseDto from(AlpacaAssetResponse alpacaAsset) {
-        return new StockDetailResponseDto(
-                alpacaAsset.symbol(),
-                alpacaAsset.name(),
-                alpacaAsset.exchange(),
-                alpacaAsset.assetClass(),
-                alpacaAsset.status(),
-                alpacaAsset.tradable(),
-                alpacaAsset.fractionable(),
-                alpacaAsset.minOrderSize(),
-                alpacaAsset.minTradeIncrement(),
-                alpacaAsset.priceIncrement(),
-                null // 추후 Clearbit 통해 로고 추가
-        );
-    }
 }
+

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/stock/dto/response/StockSearchResponseDto.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/stock/dto/response/StockSearchResponseDto.java
@@ -1,16 +1,15 @@
-package com.curihous.qbit.api.domain.stock.dto;
+package com.curihous.qbit.api.domain.stock.dto.response;
 
 import com.curihous.qbit.domain.stock.entity.Stock;
-import com.curihous.qbit.infra.alpaca.dto.response.AlpacaAssetResponse;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
- * 종목 목록 조회 응답 DTO
+ * 종목 검색 응답 DTO
  * 
  * 사용 API:
- * - GET /stocks
+ * - GET /stocks/search
  */
-@Schema(description = "종목 목록 조회 응답")
+@Schema(description = "종목 검색 응답")
 public record StockSearchResponseDto(
     
     @Schema(description = "종목 코드", example = "AAPL")
@@ -29,7 +28,6 @@ public record StockSearchResponseDto(
     String logoUrl
 ) {
     
-    // Stock 엔티티를 StockSearchResponseDto로 변환 (DB 조회용)
     public static StockSearchResponseDto fromEntity(Stock stock) {
         return new StockSearchResponseDto(
                 stock.getSymbol(),
@@ -39,15 +37,5 @@ public record StockSearchResponseDto(
                 stock.getLogoUrl()
         );
     }
-    
-    // AlpacaAssetResponse를 StockSearchResponseDto로 변환 (API 조회용)
-    public static StockSearchResponseDto from(AlpacaAssetResponse alpacaAsset) {
-        return new StockSearchResponseDto(
-                alpacaAsset.symbol(),
-                alpacaAsset.name(),
-                alpacaAsset.exchange(),
-                alpacaAsset.tradable(),
-                null // 추후 Clearbit 통해 로고 추가
-        );
-    }
 }
+

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/trading/controller/TradingController.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/trading/controller/TradingController.java
@@ -1,12 +1,12 @@
 package com.curihous.qbit.api.domain.trading.controller;
 
-import com.curihous.qbit.api.domain.trading.dto.OrderCreatedResponseDto;
-import com.curihous.qbit.api.domain.trading.dto.OrderDetailResponseDto;
-import com.curihous.qbit.infra.alpaca.dto.request.CreateOrderRequest;
-import com.curihous.qbit.infra.alpaca.dto.request.UpdateOrderRequest;
-import com.curihous.qbit.infra.alpaca.dto.response.AlpacaOrderResponse;
-import com.curihous.qbit.infra.alpaca.service.AlpacaOrderRequestService;
+import com.curihous.qbit.api.domain.trading.dto.request.CreateOrderRequestDto;
+import com.curihous.qbit.api.domain.trading.dto.request.UpdateOrderRequestDto;
+import com.curihous.qbit.api.domain.trading.dto.response.OrderCreatedResponseDto;
+import com.curihous.qbit.api.domain.trading.dto.response.OrderDetailResponseDto;
+import com.curihous.qbit.api.domain.trading.dto.response.OrderUpdateResponseDto;
 import com.curihous.qbit.domain.order.entity.OrderRequest;
+import com.curihous.qbit.domain.order.port.TradingPort;
 import com.curihous.qbit.domain.user.entity.User;
 import com.curihous.qbit.infra.security.facade.UserSecurityFacade;
 import io.swagger.v3.oas.annotations.Operation;
@@ -19,39 +19,60 @@ import org.springframework.web.bind.annotation.*;
 import java.util.List;
 import java.util.stream.Collectors;
 
-@Tag(name = "Trading", description = "모의 주식 거래 관련 API입니다")
+@Tag(name = "Trading", description = "모의 주식 거래 관련 API입니다.")
 @RestController
 @RequestMapping("/trading")
 @RequiredArgsConstructor
 public class TradingController {
 
-    private final AlpacaOrderRequestService alpacaOrderRequestService;
+    private final TradingPort tradingPort;
     private final UserSecurityFacade userSecurityFacade;
 
-    @Operation(summary = "주문 생성", description = "Alpaca를 통해 모의 주식 주문을 생성합니다")
+    @Operation(summary = "주문 생성", description = "모의 주식 주문을 생성합니다")
     @PostMapping("/orders")
-    public ResponseEntity<OrderCreatedResponseDto> createOrder(@Valid @RequestBody CreateOrderRequest request) {
+    public ResponseEntity<OrderCreatedResponseDto> createOrder(@Valid @RequestBody CreateOrderRequestDto request) {
         User user = userSecurityFacade.getCurrentUser();
-        OrderRequest orderRequest = alpacaOrderRequestService.createOrder(user, request);
+        
+        TradingPort.CreateOrderCommand command = new TradingPort.CreateOrderCommand(
+            request.symbol(),
+            request.quantity(),
+            request.side(),
+            request.type(),
+            request.timeInForce(),
+            request.limitPrice(),
+            request.stopPrice(),
+            request.clientOrderId()
+        );
+        
+        OrderRequest orderRequest = tradingPort.createOrder(user, command);
         return ResponseEntity.ok(OrderCreatedResponseDto.from(orderRequest));
     }
 
     @Operation(summary = "주문 수정", description = "미체결 또는 부분 체결된 주문의 수량, 가격 등을 수정합니다")
     @PatchMapping("/orders/{orderId}")
-    public ResponseEntity<AlpacaOrderResponse> updateOrder(
+    public ResponseEntity<OrderUpdateResponseDto> updateOrder(
             @PathVariable Long orderId,
-            @Valid @RequestBody UpdateOrderRequest request
+            @Valid @RequestBody UpdateOrderRequestDto request
     ) {
         User user = userSecurityFacade.getCurrentUser();
-        AlpacaOrderResponse response = alpacaOrderRequestService.updateOrder(user, orderId, request);
-        return ResponseEntity.ok(response);
+        
+        TradingPort.UpdateOrderCommand command = new TradingPort.UpdateOrderCommand(
+            request.quantity(),
+            request.limitPrice(),
+            request.stopPrice(),
+            request.timeInForce(),
+            request.clientOrderId()
+        );
+        
+        TradingPort.OrderUpdateResult result = tradingPort.updateOrder(user, orderId, command);
+        return ResponseEntity.ok(OrderUpdateResponseDto.from(result));
     }
 
     @Operation(summary = "내 주문 목록 조회", description = "사용자의 모든 주문 내역을 조회합니다")
     @GetMapping("/orders")
     public ResponseEntity<List<OrderDetailResponseDto>> getMyOrders() {
         User user = userSecurityFacade.getCurrentUser();
-        List<OrderRequest> orders = alpacaOrderRequestService.getMyOrders(user); // TODO: 페이징 처리
+        List<OrderRequest> orders = tradingPort.getMyOrders(user); // TODO: 페이징 처리
         List<OrderDetailResponseDto> response = orders.stream()
                 .map(OrderDetailResponseDto::from)
                 .collect(Collectors.toList());
@@ -64,7 +85,7 @@ public class TradingController {
             @PathVariable Long orderId
     ) {
         User user = userSecurityFacade.getCurrentUser();
-        OrderRequest order = alpacaOrderRequestService.getOrder(user, orderId);
+        OrderRequest order = tradingPort.getOrder(user, orderId);
         return ResponseEntity.ok(OrderDetailResponseDto.from(order));
     }
 }

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/trading/dto/request/CreateOrderRequestDto.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/trading/dto/request/CreateOrderRequestDto.java
@@ -1,0 +1,42 @@
+package com.curihous.qbit.api.domain.trading.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 주문 생성 요청 DTO
+ * 
+ * 사용 API:
+ * - POST /trading/orders
+ */
+public record CreateOrderRequestDto(
+    @NotBlank
+    @Schema(description = "종목 심볼", example = "AAPL")
+    String symbol,
+    
+    @NotBlank
+    @Schema(description = "수량", example = "10")
+    String quantity,
+    
+    @NotBlank
+    @Schema(description = "매수/매도", example = "buy", allowableValues = {"buy", "sell"})
+    String side,
+    
+    @NotBlank
+    @Schema(description = "주문 유형", example = "market", allowableValues = {"market", "limit", "stop", "stop_limit"})
+    String type,
+    
+    @NotBlank
+    @Schema(description = "주문 유효기간", example = "day", allowableValues = {"day", "gtc", "ioc", "fok"})
+    String timeInForce,
+    
+    @Schema(description = "지정가 (limit/stop_limit 시 필수)", example = "150.50")
+    String limitPrice,
+    
+    @Schema(description = "손절가 (stop/stop_limit 시 필수)", example = "145.00")
+    String stopPrice,
+    
+    @Schema(description = "클라이언트 주문 ID (선택)", example = "my-order-001")
+    String clientOrderId
+) {}
+

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/trading/dto/request/UpdateOrderRequestDto.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/trading/dto/request/UpdateOrderRequestDto.java
@@ -1,0 +1,27 @@
+package com.curihous.qbit.api.domain.trading.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 주문 수정 요청 DTO
+ * 
+ * 사용 API:
+ * - PATCH /trading/orders/{orderId}
+ */
+public record UpdateOrderRequestDto(
+    @Schema(description = "수정할 수량", example = "15")
+    String quantity,
+    
+    @Schema(description = "수정할 지정가", example = "152.00")
+    String limitPrice,
+    
+    @Schema(description = "수정할 손절가", example = "147.00")
+    String stopPrice,
+    
+    @Schema(description = "수정할 주문 유효기간", example = "gtc")
+    String timeInForce,
+    
+    @Schema(description = "수정할 클라이언트 주문 ID", example = "my-order-002")
+    String clientOrderId
+) {}
+

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/trading/dto/response/OrderCreatedResponseDto.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/trading/dto/response/OrderCreatedResponseDto.java
@@ -1,7 +1,6 @@
-package com.curihous.qbit.api.domain.trading.dto;
+package com.curihous.qbit.api.domain.trading.dto.response;
 
 import com.curihous.qbit.domain.order.entity.OrderRequest;
-import com.curihous.qbit.domain.order.entity.OrderType;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 import java.time.OffsetDateTime;
@@ -11,8 +10,6 @@ import java.time.OffsetDateTime;
  * 
  * 사용 API:
  * - POST /trading/orders
- * 
- * 주문 생성 성공 모달에 표시할 정보
  */
 @Schema(description = "주문 생성 성공 응답")
 public record OrderCreatedResponseDto(
@@ -117,3 +114,4 @@ public record OrderCreatedResponseDto(
         );
     }
 }
+

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/trading/dto/response/OrderDetailResponseDto.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/trading/dto/response/OrderDetailResponseDto.java
@@ -1,4 +1,4 @@
-package com.curihous.qbit.api.domain.trading.dto;
+package com.curihous.qbit.api.domain.trading.dto.response;
 
 import com.curihous.qbit.domain.order.entity.OrderRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -9,12 +9,9 @@ import java.time.OffsetDateTime;
  * 주문 상세 조회 응답 DTO
  * 
  * 사용 API:
- * - GET /trading/orders (목록)
- * - GET /trading/orders/{orderId} (상세)
- * 
- * 주문 히스토리/상세 화면에 표시할 정보
+ * - GET /trading/orders
+ * - GET /trading/orders/{orderId}
  */
-@Schema(description = "주문 상세 조회 응답")
 public record OrderDetailResponseDto(
     
     @Schema(description = "주문 ID (내부 DB ID)", example = "12345")

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/trading/dto/response/OrderUpdateResponseDto.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/trading/dto/response/OrderUpdateResponseDto.java
@@ -1,0 +1,94 @@
+package com.curihous.qbit.api.domain.trading.dto.response;
+
+import com.curihous.qbit.domain.order.port.TradingPort;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+/**
+ * 주문 수정 응답 DTO
+ * 
+ * 사용 API:
+ * - PATCH /trading/orders/{orderId}
+ */
+public record OrderUpdateResponseDto(
+    @Schema(description = "Alpaca 주문 ID")
+    String alpacaOrderId,
+    
+    @Schema(description = "종목 심볼")
+    String symbol,
+    
+    @Schema(description = "주문 수량")
+    String qty,
+    
+    @Schema(description = "체결 수량")
+    String filledQty,
+    
+    @Schema(description = "매수/매도")
+    String side,
+    
+    @Schema(description = "주문 유형")
+    String type,
+    
+    @Schema(description = "주문 유효기간")
+    String timeInForce,
+    
+    @Schema(description = "지정가")
+    String limitPrice,
+    
+    @Schema(description = "손절가")
+    String stopPrice,
+    
+    @Schema(description = "평균 체결가")
+    String filledAvgPrice,
+    
+    @Schema(description = "주문 상태")
+    String status,
+    
+    @Schema(description = "클라이언트 주문 ID")
+    String clientOrderId,
+    
+    @Schema(description = "생성 시간")
+    String createdAt,
+    
+    @Schema(description = "제출 시간")
+    String submittedAt,
+    
+    @Schema(description = "체결 시간")
+    String filledAt,
+    
+    @Schema(description = "취소 시간")
+    String canceledAt,
+    
+    @Schema(description = "대체 시간")
+    String replacedAt,
+    
+    @Schema(description = "대체된 주문 ID")
+    String replacedBy,
+    
+    @Schema(description = "대체하는 주문 ID")
+    String replaces
+) {
+    public static OrderUpdateResponseDto from(TradingPort.OrderUpdateResult result) {
+        return new OrderUpdateResponseDto(
+            result.alpacaOrderId(),
+            result.symbol(),
+            result.qty(),
+            result.filledQty(),
+            result.side(),
+            result.type(),
+            result.timeInForce(),
+            result.limitPrice(),
+            result.stopPrice(),
+            result.filledAvgPrice(),
+            result.status(),
+            result.clientOrderId(),
+            result.createdAt(),
+            result.submittedAt(),
+            result.filledAt(),
+            result.canceledAt(),
+            result.replacedAt(),
+            result.replacedBy(),
+            result.replaces()
+        );
+    }
+}
+

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/user/controller/UserController.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/user/controller/UserController.java
@@ -1,8 +1,8 @@
 package com.curihous.qbit.api.domain.user.controller;
 
-import com.curihous.qbit.api.domain.user.dto.*;
-import com.curihous.qbit.infra.security.facade.UserSecurityFacade;
+import com.curihous.qbit.api.domain.user.dto.response.UserResponseDto;
 import com.curihous.qbit.domain.user.entity.User;
+import com.curihous.qbit.infra.security.facade.UserSecurityFacade;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;

--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/user/dto/response/UserResponseDto.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/user/dto/response/UserResponseDto.java
@@ -1,11 +1,16 @@
-package com.curihous.qbit.api.domain.user.dto;
+package com.curihous.qbit.api.domain.user.dto.response;
 
 import com.curihous.qbit.domain.user.entity.LoginType;
 import com.curihous.qbit.domain.user.entity.User;
 
 import java.time.LocalDateTime;
 
-// TODO: 확인용 DTO이므로 제거 또는 수정 필요
+/**
+ * 사용자 정보 조회 응답 DTO
+ * 
+ * 사용 API:
+ * - GET /users/me
+ */
 public record UserResponseDto(
     Long userId,
     String email,
@@ -31,3 +36,4 @@ public record UserResponseDto(
         );
     }
 }
+

--- a/qbit-api-app/src/main/resources/application-dev.yml
+++ b/qbit-api-app/src/main/resources/application-dev.yml
@@ -46,6 +46,15 @@ alpaca:
     token-url: https://api.alpaca.markets/oauth/token
   paper-trading:
     base-url: https://paper-api.alpaca.markets
+  system:
+    api-key: ${ALPACA_SYSTEM_API_KEY}
+    secret-key: ${ALPACA_SYSTEM_SECRET_KEY}
+
+# Polygon API 설정
+polygon:
+  api:
+    key: ${POLYGON_API_KEY}
+    base-url: https://api.polygon.io
 
 # OAuth State 보안 설정
 oauth:

--- a/qbit-api-app/src/main/resources/application-dev.yml
+++ b/qbit-api-app/src/main/resources/application-dev.yml
@@ -46,15 +46,6 @@ alpaca:
     token-url: https://api.alpaca.markets/oauth/token
   paper-trading:
     base-url: https://paper-api.alpaca.markets
-  system:
-    api-key: ${ALPACA_SYSTEM_API_KEY}
-    secret-key: ${ALPACA_SYSTEM_SECRET_KEY}
-
-# Polygon API 설정
-polygon:
-  api:
-    key: ${POLYGON_API_KEY}
-    base-url: https://api.polygon.io
 
 # OAuth State 보안 설정
 oauth:

--- a/qbit-api-app/src/main/resources/application-prod.yml
+++ b/qbit-api-app/src/main/resources/application-prod.yml
@@ -70,6 +70,15 @@ alpaca:
     token-url: https://api.alpaca.markets/oauth/token
   paper-trading:
     base-url: https://paper-api.alpaca.markets
+  system:
+    api-key: ${ALPACA_SYSTEM_API_KEY}
+    secret-key: ${ALPACA_SYSTEM_SECRET_KEY}
+
+# Polygon API 설정
+polygon:
+  api:
+    key: ${POLYGON_API_KEY}
+    base-url: https://api.polygon.io
 
 # OAuth State 보안 설정
 oauth:

--- a/qbit-api-app/src/main/resources/application-prod.yml
+++ b/qbit-api-app/src/main/resources/application-prod.yml
@@ -70,16 +70,7 @@ alpaca:
     token-url: https://api.alpaca.markets/oauth/token
   paper-trading:
     base-url: https://paper-api.alpaca.markets
-  system:
-    api-key: ${ALPACA_SYSTEM_API_KEY}
-    secret-key: ${ALPACA_SYSTEM_SECRET_KEY}
-
-# Polygon API 설정
-polygon:
-  api:
-    key: ${POLYGON_API_KEY}
-    base-url: https://api.polygon.io
-
+    
 # OAuth State 보안 설정
 oauth:
   state:

--- a/qbit-api-app/src/main/resources/application.yml
+++ b/qbit-api-app/src/main/resources/application.yml
@@ -5,5 +5,5 @@ spring:
 info:
   app:
     name: QBIT-API
-    version: 4.1.3 # TODO: develop->deploy PR 시 수정
+    version: 4.2.3 # TODO: develop->deploy PR 시 수정
     description: QBIT 백엔드 API

--- a/qbit-common/src/main/java/com/curihous/qbit/common/encryption/EncryptionService.java
+++ b/qbit-common/src/main/java/com/curihous/qbit/common/encryption/EncryptionService.java
@@ -75,16 +75,7 @@ public class EncryptionService {
             Cipher cipher = Cipher.getInstance(TRANSFORMATION);
 
             // Base64 디코딩
-            byte[] encryptedWithIv;
-            try {
-                encryptedWithIv = Base64.getDecoder().decode(encryptedText);
-            } catch (IllegalArgumentException ex) {
-                // URL-safe Base64로 재시도 (-, _ 문자 포함된 경우)
-                String fixed = encryptedText.replace('-', '+').replace('_', '/');
-                int pad = (4 - (fixed.length() % 4)) % 4;
-                fixed = fixed + "=".repeat(pad);
-                encryptedWithIv = Base64.getDecoder().decode(fixed);
-            }
+            byte[] encryptedWithIv = Base64.getDecoder().decode(encryptedText);
 
             // IV와 암호화된 텍스트 분리
             byte[] iv = new byte[GCM_IV_LENGTH];

--- a/qbit-common/src/main/java/com/curihous/qbit/common/encryption/EncryptionService.java
+++ b/qbit-common/src/main/java/com/curihous/qbit/common/encryption/EncryptionService.java
@@ -75,7 +75,16 @@ public class EncryptionService {
             Cipher cipher = Cipher.getInstance(TRANSFORMATION);
 
             // Base64 디코딩
-            byte[] encryptedWithIv = Base64.getDecoder().decode(encryptedText);
+            byte[] encryptedWithIv;
+            try {
+                encryptedWithIv = Base64.getDecoder().decode(encryptedText);
+            } catch (IllegalArgumentException ex) {
+                // URL-safe Base64로 재시도 (-, _ 문자 포함된 경우)
+                String fixed = encryptedText.replace('-', '+').replace('_', '/');
+                int pad = (4 - (fixed.length() % 4)) % 4;
+                fixed = fixed + "=".repeat(pad);
+                encryptedWithIv = Base64.getDecoder().decode(fixed);
+            }
 
             // IV와 암호화된 텍스트 분리
             byte[] iv = new byte[GCM_IV_LENGTH];

--- a/qbit-common/src/main/java/com/curihous/qbit/common/exception/ErrorCode.java
+++ b/qbit-common/src/main/java/com/curihous/qbit/common/exception/ErrorCode.java
@@ -28,6 +28,10 @@ public enum ErrorCode {
     INSUFFICIENT_BALANCE(400, "잔고가 부족합니다."),
     INVALID_TRADE_CYCLE(400, "유효하지 않은 거래 사이클입니다."),
 
+    // 지수 관련 에러 - Yahoo Finance API
+    INDEX_NOT_FOUND(404, "해당 지수를 찾을 수 없습니다."),
+    INDEX_DATA_UNAVAILABLE(503, "지수 데이터를 조회할 수 없습니다."),
+
     // 401 Unauthorized
     // 로그인 상태여야 하는 요청
     NOT_AUTHENTICATED(401, "로그인 상태가 아닙니다."),

--- a/qbit-domain/src/main/java/com/curihous/qbit/domain/order/port/TradingPort.java
+++ b/qbit-domain/src/main/java/com/curihous/qbit/domain/order/port/TradingPort.java
@@ -1,0 +1,68 @@
+package com.curihous.qbit.domain.order.port;
+
+import com.curihous.qbit.domain.order.entity.OrderRequest;
+import com.curihous.qbit.domain.user.entity.User;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 주식 거래(주문) 처리를 위한 Port 인터페이스
+ * (Hexagonal Architecture - Port)
+ */
+public interface TradingPort {
+    
+    // 주문 생성
+    OrderRequest createOrder(User user, CreateOrderCommand request);
+    
+    // 주문 수정
+    OrderUpdateResult updateOrder(User user, Long orderId, UpdateOrderCommand request);
+    
+    // 내 주문 목록 조회
+    List<OrderRequest> getMyOrders(User user);
+    
+    // 특정 주문 조회
+    OrderRequest getOrder(User user, Long orderId);
+    
+    record CreateOrderCommand(
+        String symbol,           // 종목 심볼
+        String quantity,         // 수량
+        String side,             // 매수/매도 (buy/sell)
+        String type,             // 주문 유형 (market/limit/stop/stop_limit)
+        String timeInForce,      // 주문 유효기간 (day/gtc/ioc/fok)
+        String limitPrice,       // 지정가 (limit/stop_limit 시)
+        String stopPrice,        // 손절가 (stop/stop_limit 시)
+        String clientOrderId     // 클라이언트 주문 ID (선택)
+    ) {}
+    
+    record UpdateOrderCommand(
+        String quantity,         // 수정할 수량 (선택)
+        String limitPrice,       // 수정할 지정가 (선택)
+        String stopPrice,        // 수정할 손절가 (선택)
+        String timeInForce,      // 수정할 주문 유효기간 (선택)
+        String clientOrderId     // 수정할 클라이언트 주문 ID (선택)
+    ) {}
+    
+    record OrderUpdateResult(
+        String alpacaOrderId,        // Alpaca 주문 ID
+        String symbol,               // 종목 심볼
+        String qty,                  // 수량
+        String filledQty,            // 체결된 수량
+        String side,                 // 매수/매도
+        String type,                 // 주문 유형
+        String timeInForce,          // 주문 유효기간
+        String limitPrice,           // 지정가
+        String stopPrice,            // 손절가
+        String filledAvgPrice,       // 평균 체결가
+        String status,               // 주문 상태
+        String clientOrderId,        // 클라이언트 주문 ID
+        String createdAt,            // 생성 시간
+        String submittedAt,          // 제출 시간
+        String filledAt,             // 체결 시간
+        String canceledAt,           // 취소 시간
+        String replacedAt,           // 대체 시간
+        String replacedBy,           // 대체된 주문 ID
+        String replaces              // 대체하는 주문 ID
+    ) {}
+}
+

--- a/qbit-domain/src/main/java/com/curihous/qbit/domain/stock/entity/MarketIndex.java
+++ b/qbit-domain/src/main/java/com/curihous/qbit/domain/stock/entity/MarketIndex.java
@@ -1,0 +1,103 @@
+package com.curihous.qbit.domain.stock.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "market_indices")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MarketIndex {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "symbol", nullable = false, unique = true, length = 10)
+    private String symbol;
+
+    @Column(name = "name", nullable = false, length = 100)
+    private String name;
+
+    @Column(name = "description", length = 500)
+    private String description;
+
+    @Column(name = "country", length = 50)
+    private String country;
+
+    @Column(name = "currency", length = 10)
+    private String currency;
+
+    @Column(name = "current_price", precision = 19, scale = 4)
+    private BigDecimal currentPrice;
+
+    @Column(name = "previous_close", precision = 19, scale = 4)
+    private BigDecimal previousClose;
+
+    @Column(name = "change_amount", precision = 19, scale = 4)
+    private BigDecimal changeAmount;
+
+    @Column(name = "change_percentage", precision = 8, scale = 4)
+    private BigDecimal changePercentage;
+
+    @Column(name = "volume")
+    private Long volume;
+
+    @Column(name = "market_cap")
+    private Long marketCap;
+
+    @Column(name = "last_updated")
+    private LocalDateTime lastUpdated;
+
+    @Column(name = "is_active")
+    private Boolean isActive;
+
+    @Builder
+    public MarketIndex(String symbol, String name, String description, String country, 
+                      String currency, BigDecimal currentPrice, BigDecimal previousClose,
+                      BigDecimal changeAmount, BigDecimal changePercentage, Long volume,
+                      Long marketCap, LocalDateTime lastUpdated, Boolean isActive) {
+        this.symbol = symbol;
+        this.name = name;
+        this.description = description;
+        this.country = country;
+        this.currency = currency;
+        this.currentPrice = currentPrice;
+        this.previousClose = previousClose;
+        this.changeAmount = changeAmount;
+        this.changePercentage = changePercentage;
+        this.volume = volume;
+        this.marketCap = marketCap;
+        this.lastUpdated = lastUpdated;
+        this.isActive = isActive != null ? isActive : true;
+    }
+
+    public void updatePrice(BigDecimal currentPrice, BigDecimal previousClose, 
+                           BigDecimal changeAmount, BigDecimal changePercentage) {
+        this.currentPrice = currentPrice;
+        this.previousClose = previousClose;
+        this.changeAmount = changeAmount;
+        this.changePercentage = changePercentage;
+        this.lastUpdated = LocalDateTime.now();
+    }
+
+    public void updateVolume(Long volume) {
+        this.volume = volume;
+        this.lastUpdated = LocalDateTime.now();
+    }
+
+    // 상승/하락 여부 확인
+    public boolean isPositive() {
+        return changeAmount != null && changeAmount.compareTo(BigDecimal.ZERO) > 0;
+    }
+    
+    public boolean isNegative() {
+        return changeAmount != null && changeAmount.compareTo(BigDecimal.ZERO) < 0;
+    }
+}

--- a/qbit-domain/src/main/java/com/curihous/qbit/domain/stock/port/MarketIndexPort.java
+++ b/qbit-domain/src/main/java/com/curihous/qbit/domain/stock/port/MarketIndexPort.java
@@ -1,0 +1,40 @@
+package com.curihous.qbit.domain.stock.port;
+
+import com.curihous.qbit.domain.stock.entity.MarketIndex;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * 시장 지수 데이터 조회를 위한 Port 인터페이스
+ * (Hexagonal Architecture - Port)
+ * 
+ * 외부 시스템(Yahoo Finance 등)으로부터 지수 데이터를 가져오는 계약을 정의합니다.
+ * 구체적인 구현은 Infra 계층의 Adapter에서 담당합니다.
+ */
+public interface MarketIndexPort {
+    
+    // 지수 조회
+    MarketIndex getOrFetchIndex(String symbol);
+    
+    // 지수 과거 데이터 조회
+    MarketIndexHistoryData getIndexHistory(String symbol, String from, String to);
+    
+    // 허용된 주요 지수 심볼 목록
+    List<String> getMajorIndexSymbols();
+    
+    // 응집도 향상: Port와 그 계약에 사용되는 DTO를 함께 관리
+    record MarketIndexHistoryData(
+        List<HistoryPoint> dataPoints
+    ) {
+        public record HistoryPoint(
+            Long timestamp,    
+            BigDecimal openPrice,
+            BigDecimal closePrice,
+            BigDecimal highPrice,
+            BigDecimal lowPrice,
+            Long volume
+        ) {}
+    }
+}
+

--- a/qbit-domain/src/main/java/com/curihous/qbit/domain/stock/port/StockPort.java
+++ b/qbit-domain/src/main/java/com/curihous/qbit/domain/stock/port/StockPort.java
@@ -1,0 +1,15 @@
+package com.curihous.qbit.domain.stock.port;
+
+import com.curihous.qbit.domain.stock.entity.Stock;
+import com.curihous.qbit.domain.user.entity.User;
+
+/**
+ * 주식 종목 데이터 조회를 위한 Port 인터페이스
+ * (Hexagonal Architecture - Port)
+ */
+public interface StockPort {
+    
+    // 종목 조회
+    Stock getOrFetchStock(User user, String symbol);
+}
+

--- a/qbit-domain/src/main/java/com/curihous/qbit/domain/stock/repository/MarketIndexRepository.java
+++ b/qbit-domain/src/main/java/com/curihous/qbit/domain/stock/repository/MarketIndexRepository.java
@@ -14,7 +14,7 @@ public interface MarketIndexRepository extends JpaRepository<MarketIndex, Long> 
 
     Optional<MarketIndex> findBySymbol(String symbol);
 
-    // 주요 지수 목록 조회 (polygonMarketIndexService에서 country = "US", isActive = true로 설정 완료)
+    // DB에서 주요 지수 목록 조회 (배치 작업으로 동기화됨)
     @Query("SELECT m FROM MarketIndex m ORDER BY m.symbol")
     List<MarketIndex> findMajorIndices();
 }

--- a/qbit-domain/src/main/java/com/curihous/qbit/domain/stock/repository/MarketIndexRepository.java
+++ b/qbit-domain/src/main/java/com/curihous/qbit/domain/stock/repository/MarketIndexRepository.java
@@ -1,0 +1,20 @@
+package com.curihous.qbit.domain.stock.repository;
+
+import com.curihous.qbit.domain.stock.entity.MarketIndex;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface MarketIndexRepository extends JpaRepository<MarketIndex, Long> {
+
+    Optional<MarketIndex> findBySymbol(String symbol);
+
+    // 주요 지수 목록 조회 (polygonMarketIndexService에서 country = "US", isActive = true로 설정 완료)
+    @Query("SELECT m FROM MarketIndex m ORDER BY m.symbol")
+    List<MarketIndex> findMajorIndices();
+}

--- a/qbit-domain/src/main/java/com/curihous/qbit/domain/stock/service/MarketIndexService.java
+++ b/qbit-domain/src/main/java/com/curihous/qbit/domain/stock/service/MarketIndexService.java
@@ -1,0 +1,40 @@
+package com.curihous.qbit.domain.stock.service;
+
+import com.curihous.qbit.common.exception.ErrorCode;
+import com.curihous.qbit.common.exception.QbitException;
+import com.curihous.qbit.domain.stock.entity.MarketIndex;
+import com.curihous.qbit.domain.stock.port.MarketIndexPort;
+import com.curihous.qbit.domain.stock.repository.MarketIndexRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MarketIndexService {
+
+    private final MarketIndexRepository marketIndexRepository;
+    private final MarketIndexPort marketIndexPort;
+
+    // 주요 지수 조회 (배치 작업된 DB에서)
+    public List<MarketIndex> getMajorIndices() {
+        List<MarketIndex> indices = marketIndexRepository.findMajorIndices();
+        if (indices.isEmpty()) {
+            throw new QbitException(ErrorCode.INDEX_DATA_UNAVAILABLE, "DB에 지수 데이터가 없습니다. 배치 작업을 확인해주세요.");
+        }
+        return indices;
+    }
+    
+    // 허용된 지수 심볼인지 확인
+    public void validateIndexSymbol(String symbol) {
+        if (!marketIndexPort.getMajorIndexSymbols().contains(symbol)) {
+            throw new QbitException(ErrorCode.INDEX_NOT_FOUND);
+        }
+    }
+
+}

--- a/qbit-infra/src/main/java/com/curihous/qbit/infra/alpaca/service/AlpacaOrderRequestService.java
+++ b/qbit-infra/src/main/java/com/curihous/qbit/infra/alpaca/service/AlpacaOrderRequestService.java
@@ -10,8 +10,10 @@ import com.curihous.qbit.domain.alpaca.entity.AlpacaOAuthConnection;
 import com.curihous.qbit.domain.alpaca.service.AlpacaOAuthConnectionService;
 import com.curihous.qbit.domain.order.entity.OrderRequest;
 import com.curihous.qbit.domain.order.entity.*;
+import com.curihous.qbit.domain.order.port.TradingPort;
 import com.curihous.qbit.domain.order.repository.OrderRequestRepository;
 import com.curihous.qbit.domain.stock.entity.Stock;
+import com.curihous.qbit.domain.stock.port.StockPort;
 import com.curihous.qbit.domain.user.entity.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -21,20 +23,26 @@ import org.springframework.transaction.annotation.Transactional;
 import java.math.BigDecimal;
 import java.util.List;
 
+/**
+ * Alpaca API를 통한 주식 거래(주문) 처리 Adapter
+ * (Hexagonal Architecture - Adapter)
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class AlpacaOrderRequestService {
+public class AlpacaOrderRequestService implements TradingPort {
 
     private final OrderRequestRepository orderRequestRepository;
     private final AlpacaTradingPort alpacaTradingPort;
     private final AlpacaOAuthConnectionService alpacaOAuthConnectionService;
-    private final AlpacaStockService alpacaStockService;
+    private final StockPort stockPort;
 
     // 주문 생성
     @Transactional
-    public OrderRequest createOrder(User user, CreateOrderRequest request) {
+    public OrderRequest createOrder(User user, CreateOrderCommand command) {
+        // Command를 Infra DTO로 변환
+        CreateOrderRequest request = createInfraRequest(command);
         // 사용자의 활성화된 Alpaca 연결 조회
         AlpacaOAuthConnection connection = alpacaOAuthConnectionService.getValidConnection(user.getId());
         String authorization = "Bearer " + connection.getAccessToken();
@@ -49,7 +57,7 @@ public class AlpacaOrderRequestService {
         }
 
         // 2. Stock 조회/생성 (DB에 없으면 Alpaca API로 가져옴)
-        Stock stock = alpacaStockService.getOrFetchStock(user, alpacaResponse.symbol());
+        Stock stock = stockPort.getOrFetchStock(user, alpacaResponse.symbol());
 
         // 3. OrderRequest 생성 + Stock 연결
         OrderRequest orderRequest = convertToEntity(alpacaResponse, user, stock);
@@ -57,12 +65,14 @@ public class AlpacaOrderRequestService {
     }
 
     // 내 주문 목록 조회
+    @Override
     @Transactional(readOnly = true)
     public List<OrderRequest> getMyOrders(User user) {
         return orderRequestRepository.findByUserOrderByAlpacaCreatedAtDesc(user); // 결과 없으면 빈 리스트 반환
     }
 
     // 주문 상세 조회
+    @Override
     @Transactional(readOnly = true)
     public OrderRequest getOrder(User user, Long orderId) {
         return orderRequestRepository.findByIdAndUser(orderId, user)
@@ -70,8 +80,17 @@ public class AlpacaOrderRequestService {
     }
 
     // 주문 수정
+    @Override
     @Transactional
-    public AlpacaOrderResponse updateOrder(User user, Long orderId, UpdateOrderRequest request) {
+    public OrderUpdateResult updateOrder(User user, Long orderId, UpdateOrderCommand command) {
+
+        UpdateOrderRequest request = new UpdateOrderRequest(
+            parseBigDecimal(command.quantity()),
+            command.timeInForce(),
+            parseBigDecimal(command.limitPrice()),
+            parseBigDecimal(command.stopPrice()),
+            command.clientOrderId()
+        );
         // 사용자의 활성화된 Alpaca 연결 조회
         AlpacaOAuthConnection connection = alpacaOAuthConnectionService.getValidConnection(user.getId());
         String authorization = "Bearer " + connection.getAccessToken();
@@ -100,7 +119,7 @@ public class AlpacaOrderRequestService {
             
             log.info("주문 수정 완료: 기존 주문 ID={}, Alpaca ID={}, 새 Alpaca 주문={}", orderId, alpacaOrderId, newOrderResponse.id());
             
-            return newOrderResponse;
+            return convertToUpdateResult(newOrderResponse);
         } catch (QbitException e) {
             throw e;
         } catch (Exception e) {
@@ -222,6 +241,61 @@ public class AlpacaOrderRequestService {
                 log.warn("알 수 없는 주문 상태: {}", status);
                 yield OrderStatus.NEW;
             }
+        };
+    }
+    
+    private OrderUpdateResult convertToUpdateResult(AlpacaOrderResponse response) {
+        return new OrderUpdateResult(
+            response.id(),
+            response.symbol(),
+            response.qty(),
+            response.filledQty(),
+            response.side(),
+            response.type(),
+            response.timeInForce(),
+            response.limitPrice(),
+            response.stopPrice(),
+            response.filledAvgPrice(),
+            response.status(),
+            response.clientOrderId(),
+            response.createdAt() != null ? response.createdAt().toString() : null,
+            response.submittedAt() != null ? response.submittedAt().toString() : null,
+            response.filledAt() != null ? response.filledAt().toString() : null,
+            response.canceledAt() != null ? response.canceledAt().toString() : null,
+            response.replacedAt() != null ? response.replacedAt().toString() : null,
+            response.replacedBy(),
+            response.replaces()
+        );
+    }
+    
+    // Command (String)를 Infra DTO (BigDecimal)로 변환하는 헬퍼 메서드
+    private CreateOrderRequest createInfraRequest(CreateOrderCommand command) {
+        BigDecimal qty = parseBigDecimal(command.quantity());
+        BigDecimal limitPrice = parseBigDecimal(command.limitPrice());
+        BigDecimal stopPrice = parseBigDecimal(command.stopPrice());
+        
+        // 주문 타입에 따라 Factory 메서드 사용
+        return switch (command.type()) {
+            case "market" -> CreateOrderRequest.market(command.symbol(), qty, command.side());
+            case "limit" -> {
+                CreateOrderRequest req = CreateOrderRequest.limit(command.symbol(), qty, command.side(), limitPrice);
+                if (command.timeInForce() != null) req.setTimeInForce(command.timeInForce());
+                if (command.clientOrderId() != null) req.setClientOrderId(command.clientOrderId());
+                yield req;
+            }
+            case "stop" -> {
+                CreateOrderRequest req = CreateOrderRequest.stop(command.symbol(), qty, command.side(), stopPrice);
+                if (command.timeInForce() != null) req.setTimeInForce(command.timeInForce());
+                if (command.clientOrderId() != null) req.setClientOrderId(command.clientOrderId());
+                yield req;
+            }
+            case "stop_limit" -> {
+                CreateOrderRequest req = CreateOrderRequest.stopLimit(command.symbol(), qty, command.side(), stopPrice, limitPrice);
+                if (command.timeInForce() != null) req.setTimeInForce(command.timeInForce());
+                if (command.clientOrderId() != null) req.setClientOrderId(command.clientOrderId());
+                yield req;
+            }
+            default -> throw new QbitException(ErrorCode.INVALID_ORDER_TYPE, "지원하지 않는 주문 유형입니다: " + command.type());
         };
     }
 }

--- a/qbit-infra/src/main/java/com/curihous/qbit/infra/alpaca/service/AlpacaStockService.java
+++ b/qbit-infra/src/main/java/com/curihous/qbit/infra/alpaca/service/AlpacaStockService.java
@@ -7,6 +7,7 @@ import com.curihous.qbit.common.exception.QbitException;
 import com.curihous.qbit.domain.alpaca.entity.AlpacaOAuthConnection;
 import com.curihous.qbit.domain.alpaca.service.AlpacaOAuthConnectionService;
 import com.curihous.qbit.domain.stock.entity.Stock;
+import com.curihous.qbit.domain.stock.port.StockPort;
 import com.curihous.qbit.domain.stock.repository.StockRepository;
 import com.curihous.qbit.domain.user.entity.User;
 import jakarta.annotation.PostConstruct;
@@ -20,11 +21,15 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.List;
 import java.util.Optional;
 
+/**
+ * Alpaca API를 통한 주식 데이터 조회 Adapter
+ * (Hexagonal Architecture - Adapter)
+ */
 @Slf4j
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
-public class AlpacaStockService {
+public class AlpacaStockService implements StockPort {
 
     private final StockRepository stockRepository;
     private final AlpacaTradingPort alpacaTradingPort;

--- a/qbit-infra/src/main/java/com/curihous/qbit/infra/security/config/SecurityConfig.java
+++ b/qbit-infra/src/main/java/com/curihous/qbit/infra/security/config/SecurityConfig.java
@@ -36,9 +36,9 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**", "/api-docs/**").permitAll()
                         .requestMatchers("/", "/css/**", "/images/**", "/js/**", "/favicon.ico", "/h2-console/**").permitAll()
                         .requestMatchers("/auth/**").permitAll() // 카카오 네이티브 로그인 포함
-                        .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-resources/**", "/webjars/**", "/api-docs/**").permitAll()
                         .requestMatchers("/actuator/**").permitAll()
                         .anyRequest().authenticated()
                 )

--- a/qbit-infra/src/main/java/com/curihous/qbit/infra/security/jwt/JwtFilter.java
+++ b/qbit-infra/src/main/java/com/curihous/qbit/infra/security/jwt/JwtFilter.java
@@ -25,19 +25,6 @@ public class JwtFilter extends OncePerRequestFilter {
     public static final String BEARER_PREFIX = "Bearer ";
 
     @Override
-    protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getRequestURI();
-        return path.startsWith("/auth/") ||
-               path.startsWith("/swagger-ui") ||
-               path.startsWith("/v3/api-docs") ||
-               path.startsWith("/swagger-resources") ||
-               path.startsWith("/webjars/") ||
-               path.startsWith("/api-docs") ||
-               path.equals("/swagger-ui.html") ||
-               path.startsWith("/actuator/");
-    }
-
-    @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
                                     FilterChain filterChain) throws ServletException, IOException {
         String jwt = resolveToken(request);

--- a/qbit-infra/src/main/java/com/curihous/qbit/infra/yahoo/client/YahooFinanceClient.java
+++ b/qbit-infra/src/main/java/com/curihous/qbit/infra/yahoo/client/YahooFinanceClient.java
@@ -1,0 +1,31 @@
+package com.curihous.qbit.infra.yahoo.client;
+
+import com.curihous.qbit.infra.yahoo.config.YahooFinanceConfig;
+import com.curihous.qbit.infra.yahoo.dto.response.YahooFinanceChartResponse;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestParam;
+
+// Yahoo Finance API 클라이언트
+@FeignClient(
+    name = "yahoo-finance-client",
+    url = "https://query1.finance.yahoo.com",
+    configuration = YahooFinanceConfig.class
+)
+public interface YahooFinanceClient {
+
+    // 지수 차트 데이터 조회
+    @GetMapping("/v8/finance/chart/{symbol}")
+    YahooFinanceChartResponse getChart(@PathVariable("symbol") String symbol);
+
+    // 지수 과거 데이터 조회 (차트용)
+    @GetMapping("/v8/finance/chart/{symbol}")
+    YahooFinanceChartResponse getChartHistory(
+        @PathVariable("symbol") String symbol,
+        @RequestParam("interval") String interval,
+        @RequestParam("period1") long period1,
+        @RequestParam("period2") long period2
+    );
+}
+

--- a/qbit-infra/src/main/java/com/curihous/qbit/infra/yahoo/config/YahooFinanceConfig.java
+++ b/qbit-infra/src/main/java/com/curihous/qbit/infra/yahoo/config/YahooFinanceConfig.java
@@ -1,0 +1,30 @@
+package com.curihous.qbit.infra.yahoo.config;
+
+import feign.Logger;
+import feign.Request;
+import feign.codec.ErrorDecoder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class YahooFinanceConfig {
+
+    @Bean
+    public Logger.Level yahooFeignLoggerLevel() {
+        return Logger.Level.BASIC;
+    }
+
+    @Bean
+    public Request.Options yahooRequestOptions() {
+        return new Request.Options(
+                10000,  // 연결 타임아웃 (밀리초)
+                30000   // 읽기 타임아웃 (밀리초)
+        );
+    }
+
+    @Bean
+    public ErrorDecoder yahooErrorDecoder() {
+        return new YahooFinanceErrorDecoder();
+    }
+}
+

--- a/qbit-infra/src/main/java/com/curihous/qbit/infra/yahoo/config/YahooFinanceErrorDecoder.java
+++ b/qbit-infra/src/main/java/com/curihous/qbit/infra/yahoo/config/YahooFinanceErrorDecoder.java
@@ -1,0 +1,26 @@
+package com.curihous.qbit.infra.yahoo.config;
+
+import com.curihous.qbit.common.exception.ErrorCode;
+import com.curihous.qbit.common.exception.QbitException;
+import feign.Response;
+import feign.codec.ErrorDecoder;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class YahooFinanceErrorDecoder implements ErrorDecoder {
+
+    private final ErrorDecoder defaultErrorDecoder = new Default();
+
+    @Override
+    public Exception decode(String methodKey, Response response) {
+
+        return switch (response.status()) {
+            case 400 -> new QbitException(ErrorCode.INDEX_NOT_FOUND, "잘못된 지수 심볼입니다.");
+            case 404 -> new QbitException(ErrorCode.INDEX_NOT_FOUND, "해당 지수를 찾을 수 없습니다.");
+            case 429 -> new QbitException(ErrorCode.INDEX_DATA_UNAVAILABLE, "요청 한도 초과: 잠시 후 다시 시도해주세요");
+            case 500, 503 -> new QbitException(ErrorCode.INDEX_DATA_UNAVAILABLE, "Yahoo Finance 서버 오류");
+            default -> defaultErrorDecoder.decode(methodKey, response);
+        };
+    }
+}
+

--- a/qbit-infra/src/main/java/com/curihous/qbit/infra/yahoo/dto/response/YahooFinanceChartResponse.java
+++ b/qbit-infra/src/main/java/com/curihous/qbit/infra/yahoo/dto/response/YahooFinanceChartResponse.java
@@ -1,0 +1,149 @@
+package com.curihous.qbit.infra.yahoo.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+/**
+ * Yahoo Finance API 차트 응답 DTO
+ * 
+ * 사용 API:
+ * - Yahoo Finance: GET /v8/finance/chart/{symbol}
+ * - QBIT API: GET /indices
+ * - QBIT API: GET /indices/{symbol}
+ * - QBIT API: GET /indices/{symbol}/history
+ * 
+ * Record가 아닌 Class를 사용한 이유: 중첩 클래스의 역직렬화가 더 쉽게 가능
+ */
+@Data
+public class YahooFinanceChartResponse {
+
+    @JsonProperty("chart")
+    private ChartData chart;
+
+    @Data
+    public static class ChartData {
+        @JsonProperty("result")
+        private List<Result> result;
+
+        @JsonProperty("error")
+        private Object error;
+    }
+
+    @Data
+    public static class Result {
+        @JsonProperty("meta")
+        private Meta meta;
+
+        @JsonProperty("timestamp")
+        private List<Long> timestamp;
+
+        @JsonProperty("indicators")
+        private Indicators indicators;
+    }
+
+    @Data
+    public static class Meta {
+        @JsonProperty("currency")
+        private String currency;
+
+        @JsonProperty("symbol")
+        private String symbol;
+
+        @JsonProperty("exchangeName")
+        private String exchangeName;
+
+        @JsonProperty("instrumentType")
+        private String instrumentType;
+
+        @JsonProperty("regularMarketPrice")
+        private BigDecimal regularMarketPrice;
+
+        @JsonProperty("previousClose")
+        private BigDecimal previousClose;
+
+        @JsonProperty("regularMarketTime")
+        private Long regularMarketTime;
+
+        @JsonProperty("regularMarketVolume")
+        private Long regularMarketVolume;
+    }
+
+    @Data
+    public static class Indicators {
+        @JsonProperty("quote")
+        private List<Quote> quote;
+    }
+
+    @Data
+    public static class Quote {
+        @JsonProperty("open")
+        private List<BigDecimal> open;
+
+        @JsonProperty("high")
+        private List<BigDecimal> high;
+
+        @JsonProperty("low")
+        private List<BigDecimal> low;
+
+        @JsonProperty("close")
+        private List<BigDecimal> close;
+
+        @JsonProperty("volume")
+        private List<Long> volume;
+    }
+
+    // 현재 가격 반환
+    public BigDecimal getCurrentPrice() {
+        if (chart != null && chart.result != null && !chart.result.isEmpty()) {
+            Meta meta = chart.result.get(0).getMeta();
+            return meta != null ? meta.getRegularMarketPrice() : BigDecimal.ZERO;
+        }
+        return BigDecimal.ZERO;
+    }
+
+    // 전일 종가 반환
+    public BigDecimal getPreviousClose() {
+        if (chart != null && chart.result != null && !chart.result.isEmpty()) {
+            Meta meta = chart.result.get(0).getMeta();
+            return meta != null ? meta.getPreviousClose() : BigDecimal.ZERO;
+        }
+        return BigDecimal.ZERO;
+    }
+
+    // 변동 금액 반환
+    public BigDecimal getChangeAmount() {
+        return getCurrentPrice().subtract(getPreviousClose());
+    }
+
+    // 변동률 반환
+    public BigDecimal getChangePercentage() {
+        BigDecimal previous = getPreviousClose();
+        if (previous.compareTo(BigDecimal.ZERO) == 0) {
+            return BigDecimal.ZERO;
+        }
+        return getChangeAmount().divide(previous, 4, java.math.RoundingMode.HALF_UP)
+                .multiply(new BigDecimal("100"));
+    }
+
+    // 거래량 반환
+    public Long getVolume() {
+        if (chart != null && chart.result != null && !chart.result.isEmpty()) {
+            Meta meta = chart.result.get(0).getMeta();
+            return meta != null ? meta.getRegularMarketVolume() : 0L;
+        }
+        return 0L;
+    }
+
+    // 심볼 반환
+    public String getSymbol() {
+        if (chart != null && chart.result != null && !chart.result.isEmpty()) {
+            Meta meta = chart.result.get(0).getMeta();
+            return meta != null ? meta.getSymbol() : null;
+        }
+        return null;
+    }
+}
+

--- a/qbit-infra/src/main/java/com/curihous/qbit/infra/yahoo/dto/response/YahooFinanceChartResponse.java
+++ b/qbit-infra/src/main/java/com/curihous/qbit/infra/yahoo/dto/response/YahooFinanceChartResponse.java
@@ -95,11 +95,13 @@ public class YahooFinanceChartResponse {
         private List<Long> volume;
     }
 
-    // 현재 가격 반환
+    // 현재 가격 반환 
     public BigDecimal getCurrentPrice() {
         if (chart != null && chart.result != null && !chart.result.isEmpty()) {
             Meta meta = chart.result.get(0).getMeta();
-            return meta != null ? meta.getRegularMarketPrice() : BigDecimal.ZERO;
+            return meta != null && meta.getRegularMarketPrice() != null 
+                ? meta.getRegularMarketPrice() 
+                : BigDecimal.ZERO;
         }
         return BigDecimal.ZERO;
     }
@@ -108,7 +110,9 @@ public class YahooFinanceChartResponse {
     public BigDecimal getPreviousClose() {
         if (chart != null && chart.result != null && !chart.result.isEmpty()) {
             Meta meta = chart.result.get(0).getMeta();
-            return meta != null ? meta.getPreviousClose() : BigDecimal.ZERO;
+            return meta != null && meta.getPreviousClose() != null 
+                ? meta.getPreviousClose() 
+                : BigDecimal.ZERO;
         }
         return BigDecimal.ZERO;
     }

--- a/qbit-infra/src/main/java/com/curihous/qbit/infra/yahoo/service/YahooFinanceMarketIndexService.java
+++ b/qbit-infra/src/main/java/com/curihous/qbit/infra/yahoo/service/YahooFinanceMarketIndexService.java
@@ -151,9 +151,9 @@ public class YahooFinanceMarketIndexService implements MarketIndexPort {
     private String getIndexName(String symbol) {
         return switch (symbol) {
             case "^GSPC" -> "S&P 500";
-            case "^IXIC" -> "NASDAQ Composite";
-            case "^DJI" -> "Dow Jones Industrial Average";
-            case "^VIX" -> "CBOE Volatility Index";
+            case "^IXIC" -> "나스닥";
+            case "^DJI" -> "다우존스 지수";
+            case "^VIX" -> "변동성 지수(VIX)";
             default -> symbol.replace("^", "");
         };
     }

--- a/qbit-infra/src/main/java/com/curihous/qbit/infra/yahoo/service/YahooFinanceMarketIndexService.java
+++ b/qbit-infra/src/main/java/com/curihous/qbit/infra/yahoo/service/YahooFinanceMarketIndexService.java
@@ -1,0 +1,217 @@
+package com.curihous.qbit.infra.yahoo.service;
+
+import com.curihous.qbit.common.exception.ErrorCode;
+import com.curihous.qbit.common.exception.QbitException;
+import com.curihous.qbit.domain.stock.entity.MarketIndex;
+import com.curihous.qbit.domain.stock.port.MarketIndexPort;
+import com.curihous.qbit.domain.stock.repository.MarketIndexRepository;
+import com.curihous.qbit.infra.yahoo.client.YahooFinanceClient;
+import com.curihous.qbit.infra.yahoo.dto.response.YahooFinanceChartResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import jakarta.annotation.PostConstruct;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Yahoo Finance를 통한 시장 지수 데이터 조회 Adapter
+ * (Hexagonal Architecture - Adapter)
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class YahooFinanceMarketIndexService implements MarketIndexPort {
+
+    private final YahooFinanceClient yahooFinanceClient;
+    private final MarketIndexRepository marketIndexRepository;
+
+    // 조회 가능한 주요 지수 심볼들 
+    public static final List<String> MAJOR_INDEX_SYMBOLS = Arrays.asList(
+            "^GSPC",  // S&P 500 - 미국 전체 시장
+            "^IXIC",  // NASDAQ Composite - 기술주 중심
+            "^DJI",   // Dow Jones Industrial Average - 대형주 중심
+            "^VIX"    // VIX (변동성 지수) - 미국 시장 변동성 지수(공포 지수)
+    );
+
+    // 애플리케이션 시작 시 주요 지수 데이터 초기화
+    @PostConstruct
+    public void initMajorIndices() {
+        try {
+            log.info("주요 지수 데이터 초기화 시작...");
+            syncMajorIndices();
+            log.info("주요 지수 데이터 초기화 완료");
+        } catch (Exception e) {
+            log.warn("초기 지수 데이터 생성 실패 (서버는 정상 시작): {}", e.getMessage());
+        }
+    }
+
+    // 배치 작업 - 주요 지수 데이터 동기화 (평일 15분마다)
+    @Scheduled(cron = "0 */15 * * * MON-FRI", zone = "Asia/Seoul")
+    @Transactional
+    public void syncMajorIndices() {
+        try {
+            log.info("Yahoo Finance를 통한 주요 지수 데이터 동기화 시작...");
+            
+            for (String symbol : MAJOR_INDEX_SYMBOLS) {
+                try {
+                    updateIndexFromYahoo(symbol);
+                } catch (Exception e) {
+                    log.warn("지수 동기화 실패: {}", symbol, e);
+                }
+            }
+            
+            log.info("주요 지수 데이터 동기화 완료");
+            
+        } catch (Exception e) {
+            log.error("주요 지수 데이터 동기화 실패", e);
+        }
+    }
+
+    // 특정 지수 데이터 조회 및 업데이트
+    @Override
+    @Transactional
+    public MarketIndex getOrFetchIndex(String symbol) {
+        try {
+            updateIndexFromYahoo(symbol);
+            return marketIndexRepository.findBySymbol(symbol)
+                    .orElseThrow(() -> new QbitException(ErrorCode.INDEX_NOT_FOUND));
+        } catch (QbitException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("지수 데이터 조회 실패: {}", symbol, e);
+            throw new QbitException(ErrorCode.INDEX_DATA_UNAVAILABLE);
+        }
+    }
+
+    // Yahoo Finance로부터 지수 업데이트
+    private void updateIndexFromYahoo(String symbol) {
+        try {
+            YahooFinanceChartResponse yahooData = yahooFinanceClient.getChart(symbol);
+            
+            Optional<MarketIndex> existing = marketIndexRepository.findBySymbol(symbol);
+            
+            if (existing.isPresent()) {
+                // 기존 데이터 업데이트
+                MarketIndex index = existing.get();
+                index.updatePrice(
+                    yahooData.getCurrentPrice(),
+                    yahooData.getPreviousClose(),
+                    yahooData.getChangeAmount(),
+                    yahooData.getChangePercentage()
+                );
+                index.updateVolume(yahooData.getVolume());
+                marketIndexRepository.save(index);
+                
+                log.debug("지수 업데이트: {} = {}", symbol, yahooData.getCurrentPrice());
+            } else {
+                // 새 지수 생성
+                createIndexFromYahooData(yahooData);
+            }
+        } catch (Exception e) {
+            log.error("Yahoo Finance 지수 조회 실패: {}", symbol, e);
+            throw e;
+        }
+    }
+
+    // Yahoo 데이터로부터 새 지수 생성
+    private MarketIndex createIndexFromYahooData(YahooFinanceChartResponse yahooData) {
+        String symbol = yahooData.getSymbol();
+        String name = getIndexName(symbol);
+        
+        MarketIndex index = MarketIndex.builder()
+                .symbol(symbol)
+                .name(name)
+                .description(name + " 지수")
+                .country("US")
+                .currency("USD")
+                .currentPrice(yahooData.getCurrentPrice())
+                .previousClose(yahooData.getPreviousClose())
+                .changeAmount(yahooData.getChangeAmount())
+                .changePercentage(yahooData.getChangePercentage())
+                .volume(yahooData.getVolume())
+                .marketCap(null)
+                .lastUpdated(LocalDateTime.now())
+                .isActive(true)
+                .build();
+        
+        MarketIndex saved = marketIndexRepository.save(index);
+        log.info("새 지수 생성: {} - {}", symbol, name);
+        
+        return saved;
+    }
+
+    // 심볼로 지수명 매핑
+    private String getIndexName(String symbol) {
+        return switch (symbol) {
+            case "^GSPC" -> "S&P 500";
+            case "^IXIC" -> "NASDAQ Composite";
+            case "^DJI" -> "Dow Jones Industrial Average";
+            case "^VIX" -> "CBOE Volatility Index";
+            default -> symbol.replace("^", "");
+        };
+    }
+
+    // 과거 데이터 조회
+    @Override
+    public MarketIndexHistoryData getIndexHistory(String symbol, String from, String to) {
+        try {
+            // yyyy-MM-dd → Unix timestamp 변환
+            long period1 = java.time.LocalDate.parse(from).atStartOfDay(java.time.ZoneId.of("UTC")).toEpochSecond();
+            long period2 = java.time.LocalDate.parse(to).atStartOfDay(java.time.ZoneId.of("UTC")).toEpochSecond();
+            
+            YahooFinanceChartResponse yahooData = yahooFinanceClient.getChartHistory(symbol, "1d", period1, period2);
+            
+            // Yahoo Finance 응답을 Domain DTO로 변환
+            return convertToHistoryData(yahooData);
+        } catch (Exception e) {
+            log.error("Yahoo Finance 과거 데이터 조회 실패: symbol={}, from={}, to={}", symbol, from, to, e);
+            throw new QbitException(ErrorCode.INDEX_DATA_UNAVAILABLE, "지수 과거 데이터를 조회할 수 없습니다.");
+        }
+    }
+    
+    // 주요 지수 심볼 목록 반환
+    @Override
+    public List<String> getMajorIndexSymbols() {
+        return MAJOR_INDEX_SYMBOLS;
+    }
+    
+    // Yahoo Finance 응답을 Domain DTO로 변환
+    private MarketIndexHistoryData convertToHistoryData(YahooFinanceChartResponse yahooData) {
+        if (yahooData.getChart() == null || yahooData.getChart().getResult() == null 
+            || yahooData.getChart().getResult().isEmpty()) {
+            return new MarketIndexHistoryData(List.of());
+        }
+
+        YahooFinanceChartResponse.Result result = yahooData.getChart().getResult().get(0);
+        List<Long> timestamps = result.getTimestamp();
+        
+        if (result.getIndicators() == null || result.getIndicators().getQuote() == null 
+            || result.getIndicators().getQuote().isEmpty()) {
+            return new MarketIndexHistoryData(List.of());
+        }
+
+        YahooFinanceChartResponse.Quote quote = result.getIndicators().getQuote().get(0);
+        
+        List<MarketIndexHistoryData.HistoryPoint> dataPoints = 
+            java.util.stream.IntStream.range(0, timestamps.size())
+                .mapToObj(i -> new MarketIndexHistoryData.HistoryPoint(
+                    timestamps.get(i) * 1000, // 초 → 밀리초
+                    quote.getOpen().get(i),
+                    quote.getClose().get(i),
+                    quote.getHigh().get(i),
+                    quote.getLow().get(i),
+                    quote.getVolume().get(i)
+                ))
+                .collect(Collectors.toList());
+        
+        return new MarketIndexHistoryData(dataPoints);
+    }
+}
+

--- a/qbit-infra/src/main/java/com/curihous/qbit/infra/yahoo/service/YahooFinanceMarketIndexService.java
+++ b/qbit-infra/src/main/java/com/curihous/qbit/infra/yahoo/service/YahooFinanceMarketIndexService.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import jakarta.annotation.PostConstruct;
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
@@ -95,10 +96,21 @@ public class YahooFinanceMarketIndexService implements MarketIndexPort {
         try {
             YahooFinanceChartResponse yahooData = yahooFinanceClient.getChart(symbol);
             
+            // ZERO 데이터 검증 (Yahoo API에서 데이터를 제대로 못 받아온 경우)
+            BigDecimal currentPrice = yahooData.getCurrentPrice();
+            boolean isInvalidData = currentPrice.compareTo(BigDecimal.ZERO) == 0;
+            
             Optional<MarketIndex> existing = marketIndexRepository.findBySymbol(symbol);
             
             if (existing.isPresent()) {
-                // 기존 데이터 업데이트
+                // 기존 데이터가 있는 경우
+                if (isInvalidData) {
+                    // 가격이 ZERO면 업데이트 없이 기존 데이터 유지
+                    log.warn("Yahoo Finance 데이터 이상: {} - 가격이 0입니다. 기존 데이터 유지", symbol);
+                    return;
+                }
+                
+                // 정상 데이터로 업데이트
                 MarketIndex index = existing.get();
                 index.updatePrice(
                     yahooData.getCurrentPrice(),
@@ -111,7 +123,10 @@ public class YahooFinanceMarketIndexService implements MarketIndexPort {
                 
                 log.debug("지수 업데이트: {} = {}", symbol, yahooData.getCurrentPrice());
             } else {
-                // 새 지수 생성
+                // 데이터가 0으로 이상해도 초기 데이터가 없으므로 저장하긴 함. 
+                if (isInvalidData) {
+                    log.warn("Yahoo Finance 초기 데이터 이상: {} - 가격이 0입니다. 저장하지만 확인 필요", symbol);
+                }
                 createIndexFromYahooData(yahooData);
             }
         } catch (Exception e) {
@@ -164,7 +179,8 @@ public class YahooFinanceMarketIndexService implements MarketIndexPort {
         try {
             // yyyy-MM-dd → Unix timestamp 변환
             long period1 = java.time.LocalDate.parse(from).atStartOfDay(java.time.ZoneId.of("UTC")).toEpochSecond();
-            long period2 = java.time.LocalDate.parse(to).atStartOfDay(java.time.ZoneId.of("UTC")).toEpochSecond();
+            // period2는 exclusive이므로 +1일 해서 'to' 날짜까지 포함되도록 함
+            long period2 = java.time.LocalDate.parse(to).plusDays(1).atStartOfDay(java.time.ZoneId.of("UTC")).toEpochSecond();
             
             YahooFinanceChartResponse yahooData = yahooFinanceClient.getChartHistory(symbol, "1d", period1, period2);
             


### PR DESCRIPTION
## 🎯 목적
<!-- 이 PR의 목적과 해결하려는 문제를 설명해주세요 -->
- Qbit version 4.2.3: [Yahoo API 활용한 해외 지수 조회](https://github.com/Curihous/QBIT-BE/commit/f86180f0e01d90daed221c366906feb48e8e026a) 기능 배포

## 📝 주요 변경사항
<!-- CodeRabbit이 자동으로 변경사항을 분석하므로, 여기서는 주요 목적과 의도만 간단히 작성해주세요 -->
- Port/Adapter 패턴 적용
- Yahoo API 활용한 해외 지수 조회 기능 구현
<img width="905" height="475" alt="image" src="https://github.com/user-attachments/assets/7250c886-703c-4f8b-bb04-b95d00ab29c5" />

## 🔗 관련 이슈/PR
<!-- 관련된 이슈/PR이 있다면 링크해주세요 -->
- Related to #20 

## 🔄 버전 검토
- [x] 배포 버전 변경 시 application.yml 업데이트 필요
- [x] 캐시 불호환 변경 시 deploy.yml 업데이트 필요

## 🧪 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과
- [x] 수동 테스트 완료

## 📋 체크리스트
- [x] API 스펙 변경사항 문서화 (Swagger 업데이트)
- [x] 프론트엔드에 필요한 환경 변수 안내
- [ ] 데이터베이스 스키마 변경사항 공유
- [ ] API 응답 형식 변경 여부 확인
- [ ] 에러 코드 변경사항 공유
- [x] CodeRabbit 제안사항 검토 완료

---

<details>
<summary>📝 커밋 메시지 규칙</summary>

| 타입 | 설명 |
|------|------|
| `feat` | 새로운 기능 추가 (API, 도메인 로직 등) |
| `fix` | 버그 수정 (Null 오류, 예외 처리 등) |
| `refactor` | 리팩토링 (기능 변화 없이 구조 개선) |
| `style` | 코드 스타일 수정 (공백, 들여쓰기 등) |
| `docs` | 문서 수정 (README, Swagger, 주석 등) |
| `test` | 테스트 코드 추가/수정 |
| `chore` | 설정/빌드 관련 변경 (Gradle, .gitignore 등) |
| `perf` | 성능 개선 (쿼리 최적화 등) |
| `ci` | CI/CD 관련 설정 변경 (Jenkins, GitHub Actions 등) |
| `env` | 환경 변수(.env) 또는 비밀 키 관련 변경 |

**예시**: `feat: 사용자 인증 API 추가`

</details>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 해외 주요 지수 API 추가: 목록, 상세, 히스토리 조회 제공.
  - 지수 데이터 주기 동기화(스케줄링) 도입.
  - 주문 생성/수정 요청 DTO 및 업데이트 응답 DTO 추가로 주문 흐름 개선.
- 리팩터
  - 주식/트레이딩을 Port 기반 아키텍처로 전환하고 컨트롤러를 신규 DTO/Port로 연결.
  - DTO 패키지 정리 및 불필요한 변환 메서드 제거.
- 문서
  - Swagger 스키마/주석 보강으로 API 명세 개선.
- 잡무
  - 앱 버전 4.2.3로 업데이트.
  - OAuth 상태 시크릿 설정 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->