### PR TITLE
[FIX] 로그인 시 Alpaca WebSocket 자동 구독 추가

### DIFF
--- a/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/trading/service/AlpacaOrderTransactionalService.java
+++ b/qbit-api-app/src/main/java/com/curihous/qbit/api/domain/trading/service/AlpacaOrderTransactionalService.java
@@ -217,7 +217,7 @@ public class AlpacaOrderTransactionalService {
         };
     }
 
-    private OrderStatus convertToOrderStatus(String status) {
+    public OrderStatus convertToOrderStatus(String status) {
         return switch (status.toLowerCase()) {
             case "new" -> OrderStatus.NEW;
             case "pending_new" -> OrderStatus.PENDING_NEW;

--- a/qbit-common/src/main/java/com/curihous/qbit/common/event/LoginOrderSyncEvent.java
+++ b/qbit-common/src/main/java/com/curihous/qbit/common/event/LoginOrderSyncEvent.java
@@ -6,11 +6,16 @@ import lombok.RequiredArgsConstructor;
 /**
  * 로그인 시 주문 동기화 이벤트
  * 
- * 사용 지점: AlpacaOrderSyncService.syncOrdersOnLogin
+ * 사용 지점: AlpacaOrderSyncService.syncOrdersOnLogin, AlpacaTradeUpdatesManager
  */
 @Getter
 @RequiredArgsConstructor
 public class LoginOrderSyncEvent {
     private final Long userId;
     private final String userEmail;
+    private final String accessToken;  // Alpaca OAuth access token
+    
+    public LoginOrderSyncEvent(Long userId, String userEmail) {
+        this(userId, userEmail, null);
+    }
 }

--- a/qbit-domain/src/main/java/com/curihous/qbit/domain/order/repository/OrderRequestRepository.java
+++ b/qbit-domain/src/main/java/com/curihous/qbit/domain/order/repository/OrderRequestRepository.java
@@ -1,6 +1,7 @@
 package com.curihous.qbit.domain.order.repository;
 
 import com.curihous.qbit.domain.order.entity.OrderRequest;
+import com.curihous.qbit.domain.order.entity.OrderStatus;
 import com.curihous.qbit.domain.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -24,4 +25,7 @@ public interface OrderRequestRepository extends JpaRepository<OrderRequest, Long
     
     // 사용자의 Alpaca 주문 ID로 조회
     Optional<OrderRequest> findByAlpacaOrderIdAndUser(String alpacaOrderId, User user);
+    
+    // 상태별 주문 조회
+    List<OrderRequest> findByStatusIn(List<OrderStatus> statuses);
 }

--- a/qbit-infra/src/main/java/com/curihous/qbit/infra/alpaca/service/AlpacaOAuthService.java
+++ b/qbit-infra/src/main/java/com/curihous/qbit/infra/alpaca/service/AlpacaOAuthService.java
@@ -96,11 +96,12 @@ public class AlpacaOAuthService implements TradingPort {
             );
 
             // 트랜잭션 커밋 후 로그인 시 주문 상태 동기화 이벤트 발행
+            String alpacaAccessToken = tokenResponse.accessToken();
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
                 public void afterCommit() {
                     log.info("트랜잭션 커밋 완료, 주문 동기화 이벤트 발행: userId={}", user.getId());
-                    eventPublisher.publishEvent(new LoginOrderSyncEvent(user.getId(), user.getEmail()));
+                    eventPublisher.publishEvent(new LoginOrderSyncEvent(user.getId(), user.getEmail(), alpacaAccessToken));
                 }
             });
 

--- a/qbit-realtime-app/src/main/java/com/curihous/qbit/realtime/websocket/AlpacaTradeUpdatesManager.java
+++ b/qbit-realtime-app/src/main/java/com/curihous/qbit/realtime/websocket/AlpacaTradeUpdatesManager.java
@@ -154,8 +154,7 @@ public class AlpacaTradeUpdatesManager implements WebSocketHandler {
             Map<String, Object> authMessage = Map.of(
                 "action", "authenticate",
                 "data", Map.of(
-                    "key_id", accessToken,  
-                    "secret_key", ""     
+                    "oauth_token", accessToken
                 )
             );
             
@@ -212,7 +211,7 @@ public class AlpacaTradeUpdatesManager implements WebSocketHandler {
             log.debug("Alpaca 메시지 수신: stream={}, payload={}", stream, payload);
             
             switch (stream) {
-                case "authentication":
+                case "authorization":
                     handleAuthorizationMessage(session, root);
                     break;
                 case "listening":
@@ -255,8 +254,10 @@ public class AlpacaTradeUpdatesManager implements WebSocketHandler {
         log.info("Alpaca 인증 응답: status={}, action={}, sessionId={}", 
                 status, action, session.getId());
         
-        if ("authenticated".equals(status) && "authenticate".equals(action)) {
-            log.info("Alpaca 인증 성공 - trade_updates 자동 구독됨: sessionId={}", session.getId());
+        if ("authorized".equals(status) && "authenticate".equals(action)) {
+            log.info("Alpaca 인증 성공: sessionId={}", session.getId());
+            // 인증 성공 후 명시적으로 구독
+            sendListenMessage(session);
         } else {
             log.error("Alpaca 인증 실패: status={}, action={}, sessionId={}", 
                     status, action, session.getId());

--- a/qbit-realtime-app/src/main/java/com/curihous/qbit/realtime/websocket/AlpacaTradeUpdatesManager.java
+++ b/qbit-realtime-app/src/main/java/com/curihous/qbit/realtime/websocket/AlpacaTradeUpdatesManager.java
@@ -1,8 +1,6 @@
 package com.curihous.qbit.realtime.websocket;
 
 import com.curihous.qbit.common.event.LoginOrderSyncEvent;
-import com.curihous.qbit.domain.alpaca.entity.AlpacaOAuthConnection;
-import com.curihous.qbit.domain.alpaca.repository.AlpacaOAuthConnectionRepository;
 import com.curihous.qbit.realtime.handler.TradeUpdatesEventHandler;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -32,8 +30,10 @@ public class AlpacaTradeUpdatesManager implements WebSocketHandler {
     // 세션 -> 사용자 ID 역매핑
     private final Map<WebSocketSession, Long> sessionToUserId;
     
+    // 사용자 ID별 OAuth Access Token 저장 (재연결 시 사용)
+    private final Map<Long, String> userAccessTokens;
+    
     private final TradeUpdatesEventHandler eventHandler;
-    private final AlpacaOAuthConnectionRepository alpacaOAuthConnectionRepository;
     
     private volatile WebSocketClient webSocketClient;
     
@@ -42,13 +42,12 @@ public class AlpacaTradeUpdatesManager implements WebSocketHandler {
     private final ScheduledExecutorService reconnectScheduler = 
         Executors.newScheduledThreadPool(1);
     
-    public AlpacaTradeUpdatesManager(TradeUpdatesEventHandler eventHandler,
-                                     AlpacaOAuthConnectionRepository alpacaOAuthConnectionRepository) {
+    public AlpacaTradeUpdatesManager(TradeUpdatesEventHandler eventHandler) {
         this.objectMapper = new ObjectMapper();
         this.userSessions = new ConcurrentHashMap<>();
         this.sessionToUserId = new ConcurrentHashMap<>();
+        this.userAccessTokens = new ConcurrentHashMap<>();
         this.eventHandler = eventHandler;
-        this.alpacaOAuthConnectionRepository = alpacaOAuthConnectionRepository;
     }
     
     public void initialize(WebSocketClient webSocketClient) {
@@ -60,26 +59,28 @@ public class AlpacaTradeUpdatesManager implements WebSocketHandler {
     @EventListener
     public void handleLoginOrderSyncEvent(LoginOrderSyncEvent event) {
         log.info("로그인 이벤트 수신 - Alpaca WebSocket 구독 시작: userId={}", event.getUserId());
-        subscribe(event.getUserId());
+        
+        if (event.getAccessToken() == null || event.getAccessToken().isEmpty()) {
+            log.warn("Access Token이 없습니다: userId={}", event.getUserId());
+            return;
+        }
+        
+        // Access Token 저장
+        userAccessTokens.put(event.getUserId(), event.getAccessToken());
+        
+        subscribe(event.getUserId(), event.getAccessToken());
     }
     
-    public void subscribe(Long userId) {
+    public void subscribe(Long userId, String accessToken) {
         if (userSessions.containsKey(userId)) {
             log.debug("이미 구독 중인 사용자: userId={}", userId);
             return;
         }
         
-        // Alpaca OAuth 연결 조회
-        AlpacaOAuthConnection connection = alpacaOAuthConnectionRepository
-                .findByUserId(userId)
-                .orElse(null);
+        // Access Token 저장
+        userAccessTokens.put(userId, accessToken);
         
-        if (connection == null) {
-            log.warn("Alpaca OAuth 연결 없음: userId={}", userId);
-            return;
-        }
-        
-        connectToAlpaca(userId, connection.getAccessToken());
+        connectToAlpaca(userId, accessToken);
     }
     
     // 구독 해제
@@ -322,21 +323,19 @@ public class AlpacaTradeUpdatesManager implements WebSocketHandler {
         }
         // 세션 정리
         sessionToUserId.remove(session);
-        userSessions.remove(userId);  
+        userSessions.remove(userId);
         
-        // 재연결 시도
+        // 재연결 시도 (저장된 Access Token 사용)
+        String savedAccessToken = userAccessTokens.get(userId);
+        if (savedAccessToken == null) {
+            log.warn("재연결 실패: Access Token 없음: userId={}", userId);
+            return;
+        }
+        
         log.info("Alpaca WebSocket 재연결 시도: userId={}", userId);
         reconnectScheduler.schedule(() -> {
             if (!userSessions.containsKey(userId)) {
-                AlpacaOAuthConnection connection = alpacaOAuthConnectionRepository
-                        .findByUserId(userId)
-                        .orElse(null);
-                
-                if (connection != null) {
-                    connectToAlpaca(userId, connection.getAccessToken());
-                } else {
-                    log.warn("재연결 실패: OAuth 연결 없음: userId={}", userId);
-                }
+                subscribe(userId, savedAccessToken);
             }
         }, 5, TimeUnit.SECONDS);
     }

--- a/qbit-realtime-app/src/main/java/com/curihous/qbit/realtime/websocket/AlpacaTradeUpdatesManager.java
+++ b/qbit-realtime-app/src/main/java/com/curihous/qbit/realtime/websocket/AlpacaTradeUpdatesManager.java
@@ -1,9 +1,13 @@
 package com.curihous.qbit.realtime.websocket;
 
+import com.curihous.qbit.common.event.LoginOrderSyncEvent;
+import com.curihous.qbit.domain.alpaca.entity.AlpacaOAuthConnection;
+import com.curihous.qbit.domain.alpaca.repository.AlpacaOAuthConnectionRepository;
 import com.curihous.qbit.realtime.handler.TradeUpdatesEventHandler;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import org.springframework.web.socket.*;
 import org.springframework.web.socket.client.WebSocketClient;
@@ -28,10 +32,8 @@ public class AlpacaTradeUpdatesManager implements WebSocketHandler {
     // 세션 -> 사용자 ID 역매핑
     private final Map<WebSocketSession, Long> sessionToUserId;
     
-    // 사용자별 인증 정보 
-    private final Map<Long, AlpacaCredentials> userCredentials;
-    
     private final TradeUpdatesEventHandler eventHandler;
+    private final AlpacaOAuthConnectionRepository alpacaOAuthConnectionRepository;
     
     private volatile WebSocketClient webSocketClient;
     
@@ -40,15 +42,13 @@ public class AlpacaTradeUpdatesManager implements WebSocketHandler {
     private final ScheduledExecutorService reconnectScheduler = 
         Executors.newScheduledThreadPool(1);
     
-    // 인증 정보
-    public record AlpacaCredentials(String apiKey, String apiSecret) {}
-    
-    public AlpacaTradeUpdatesManager(TradeUpdatesEventHandler eventHandler) {
+    public AlpacaTradeUpdatesManager(TradeUpdatesEventHandler eventHandler,
+                                     AlpacaOAuthConnectionRepository alpacaOAuthConnectionRepository) {
         this.objectMapper = new ObjectMapper();
         this.userSessions = new ConcurrentHashMap<>();
         this.sessionToUserId = new ConcurrentHashMap<>();
-        this.userCredentials = new ConcurrentHashMap<>();
         this.eventHandler = eventHandler;
+        this.alpacaOAuthConnectionRepository = alpacaOAuthConnectionRepository;
     }
     
     public void initialize(WebSocketClient webSocketClient) {
@@ -56,20 +56,35 @@ public class AlpacaTradeUpdatesManager implements WebSocketHandler {
         log.info("Alpaca Trade Updates WebSocket 매니저 초기화 완료");
     }
     
-    public void subscribe(Long userId, String apiKey, String apiSecret) {
+    // 로그인 시 자동 WebSocket 구독
+    @EventListener
+    public void handleLoginOrderSyncEvent(LoginOrderSyncEvent event) {
+        log.info("로그인 이벤트 수신 - Alpaca WebSocket 구독 시작: userId={}", event.getUserId());
+        subscribe(event.getUserId());
+    }
+    
+    public void subscribe(Long userId) {
         if (userSessions.containsKey(userId)) {
             log.debug("이미 구독 중인 사용자: userId={}", userId);
             return;
-        }   
-        // 인증 정보 저장
-        userCredentials.put(userId, new AlpacaCredentials(apiKey, apiSecret));
-        connectToAlpaca(userId);
+        }
+        
+        // Alpaca OAuth 연결 조회
+        AlpacaOAuthConnection connection = alpacaOAuthConnectionRepository
+                .findByUserId(userId)
+                .orElse(null);
+        
+        if (connection == null) {
+            log.warn("Alpaca OAuth 연결 없음: userId={}", userId);
+            return;
+        }
+        
+        connectToAlpaca(userId, connection.getAccessToken());
     }
     
     // 구독 해제
     public void unsubscribe(Long userId) {
         WebSocketSession session = userSessions.remove(userId);
-        userCredentials.remove(userId);
         
         if (session != null) {
             sessionToUserId.remove(session);
@@ -86,13 +101,7 @@ public class AlpacaTradeUpdatesManager implements WebSocketHandler {
     }
     
     // 연결
-    private void connectToAlpaca(Long userId) {
-        AlpacaCredentials credentials = userCredentials.get(userId);
-        if (credentials == null) {
-            log.error("인증 정보 없음: userId={}", userId);
-            return;
-        }
-        
+    private void connectToAlpaca(Long userId, String accessToken) {
         String url = ALPACA_STREAM_URL;
         
         int maxAttempts = 3;
@@ -114,7 +123,7 @@ public class AlpacaTradeUpdatesManager implements WebSocketHandler {
                 sessionToUserId.put(session, userId);
                 
                 log.info("Alpaca WebSocket 연결 성공: userId={}", userId);
-                sendAuthMessage(session, credentials);
+                sendAuthMessage(session, accessToken);
                 return;
                 
             } catch (Exception e) {
@@ -139,12 +148,14 @@ public class AlpacaTradeUpdatesManager implements WebSocketHandler {
     }
     
     // 인증 메시지 전송
-    private void sendAuthMessage(WebSocketSession session, AlpacaCredentials credentials) {
+    private void sendAuthMessage(WebSocketSession session, String accessToken) {
         try {
             Map<String, Object> authMessage = Map.of(
-                "action", "auth",
-                "key", credentials.apiKey(),
-                "secret", credentials.apiSecret()
+                "action", "authenticate",
+                "data", Map.of(
+                    "key_id", accessToken,  
+                    "secret_key", ""     
+                )
             );
             
             String json = objectMapper.writeValueAsString(authMessage);
@@ -200,7 +211,7 @@ public class AlpacaTradeUpdatesManager implements WebSocketHandler {
             log.debug("Alpaca 메시지 수신: stream={}, payload={}", stream, payload);
             
             switch (stream) {
-                case "authorization":
+                case "authentication":
                     handleAuthorizationMessage(session, root);
                     break;
                 case "listening":
@@ -243,10 +254,8 @@ public class AlpacaTradeUpdatesManager implements WebSocketHandler {
         log.info("Alpaca 인증 응답: status={}, action={}, sessionId={}", 
                 status, action, session.getId());
         
-        if ("authorized".equals(status) && "authenticate".equals(action)) {
-            log.info("Alpaca 인증 성공: sessionId={}", session.getId());
-            // 인증 성공 후 trade_updates 구독
-            sendListenMessage(session);
+        if ("authenticated".equals(status) && "authenticate".equals(action)) {
+            log.info("Alpaca 인증 성공 - trade_updates 자동 구독됨: sessionId={}", session.getId());
         } else {
             log.error("Alpaca 인증 실패: status={}, action={}, sessionId={}", 
                     status, action, session.getId());
@@ -314,16 +323,22 @@ public class AlpacaTradeUpdatesManager implements WebSocketHandler {
         // 세션 정리
         sessionToUserId.remove(session);
         userSessions.remove(userId);  
-        // 인증 정보가 남아있으면 재연결
-        if (userCredentials.containsKey(userId)) {
-            log.info("Alpaca WebSocket 재연결 예약: userId={}", userId);
-            // 5초 후 재연결 시도
-            reconnectScheduler.schedule(() -> {
-                if (userCredentials.containsKey(userId)) {
-                    connectToAlpaca(userId);
+        
+        // 재연결 시도
+        log.info("Alpaca WebSocket 재연결 시도: userId={}", userId);
+        reconnectScheduler.schedule(() -> {
+            if (!userSessions.containsKey(userId)) {
+                AlpacaOAuthConnection connection = alpacaOAuthConnectionRepository
+                        .findByUserId(userId)
+                        .orElse(null);
+                
+                if (connection != null) {
+                    connectToAlpaca(userId, connection.getAccessToken());
+                } else {
+                    log.warn("재연결 실패: OAuth 연결 없음: userId={}", userId);
                 }
-            }, 5, TimeUnit.SECONDS);
-        }
+            }
+        }, 5, TimeUnit.SECONDS);
     }
     
     @Override


### PR DESCRIPTION
## 🎯 목적
<!-- 이 PR의 목적과 해결하려는 문제를 설명해주세요 -->
<img width="2668" height="518" alt="image" src="https://github.com/user-attachments/assets/70bbf4d2-1464-4bcc-994d-d85ef50d9be9" />
프론트에서 JWT토큰 문제가 해결되고 ws구독이 성공적으로 되었음에도, 주문 변경 상태를 웹소켓을 통해 실시간으로 수신하지 못하는 문제 해결 시도, 공식문서 참고

## 📝 주요 변경사항
<!-- CodeRabbit이 자동으로 변경사항을 분석하므로, 여기서는 주요 목적과 의도만 간단히 작성해주세요 -->
로그인 시 Alpaca WebSocket 자동 구독 추가

## 🔗 공식문서 참고
- https://docs.alpaca.markets/docs/websocket-streaming
- https://docs.alpaca.markets/docs/using-oauth2-and-trading-api

## 🔄 버전 검토
- [ ] 배포 버전 변경 시 application.yml 업데이트 필요
- [ ] 캐시 불호환 변경 시 deploy.yml 업데이트 필요

## 🧪 테스트
- [ ] 단위 테스트 통과
- [ ] 통합 테스트 통과
- [x] 수동 테스트 완료

## 📋 체크리스트
- [ ] API 스펙 변경사항 문서화 (Swagger 업데이트)
- [ ] 프론트엔드에 필요한 환경 변수 안내
- [ ] 데이터베이스 스키마 변경사항 공유
- [ ] API 응답 형식 변경 여부 확인
- [ ] 에러 코드 변경사항 공유
- [ ] CodeRabbit 제안사항 검토 완료

---

<details>
<summary>📝 커밋 메시지 규칙</summary>

| 타입 | 설명 |
|------|------|
| `feat` | 새로운 기능 추가 (API, 도메인 로직 등) |
| `fix` | 버그 수정 (Null 오류, 예외 처리 등) |
| `refactor` | 리팩토링 (기능 변화 없이 구조 개선) |
| `style` | 코드 스타일 수정 (공백, 들여쓰기 등) |
| `docs` | 문서 수정 (README, Swagger, 주석 등) |
| `test` | 테스트 코드 추가/수정 |
| `chore` | 설정/빌드 관련 변경 (Gradle, .gitignore 등) |
| `perf` | 성능 개선 (쿼리 최적화 등) |
| `ci` | CI/CD 관련 설정 변경 (Jenkins, GitHub Actions 등) |
| `env` | 환경 변수(.env) 또는 비밀 키 관련 변경 |

**예시**: `feat: 사용자 인증 API 추가`

</details>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 여러 상태로 주문을 필터링하는 기능이 추가되었습니다.
  * 로그인 시 실시간 주문 동기화가 OAuth 토큰으로 자동 트리거되도록 개선되었습니다.

* **보안 개선**
  * Alpaca WebSocket 연결이 OAuth 기반 인증으로 전환되어 인증 흐름이 강화되었습니다.

* **리팩토링**
  * 실시간 구독 및 인증 흐름이 토큰 기반으로 재구성되어 안정성과 재연결 동작이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->